### PR TITLE
feat: add ability to upload tos/eula of app

### DIFF
--- a/spaceship/lib/spaceship/tunes/app_details.rb
+++ b/spaceship/lib/spaceship/tunes/app_details.rb
@@ -43,6 +43,10 @@ module Spaceship
 
       attr_accessor :available_primary_locale_codes
 
+      attr_accessor :license
+
+      attr_accessor :eula
+
       attr_mapping(
         'localizedMetadata.value' => :languages,
         'primaryCategory.value' => :primary_category,
@@ -52,7 +56,9 @@ module Spaceship
         'secondaryFirstSubCategory.value' => :secondary_first_sub_category,
         'secondarySecondSubCategory.value' => :secondary_second_sub_category,
         'primaryLocaleCode.value' => :primary_locale_code,
-        'availablePrimaryLocaleCodes' => :available_primary_locale_codes
+        'availablePrimaryLocaleCodes' => :available_primary_locale_codes,
+        "license" => :license,
+        "license.EULAText" => :eula
       )
 
       class << self
@@ -91,6 +97,10 @@ module Spaceship
 
       # Custom Setters
       #
+      def eula=(value)
+        self.license['EULAText'] = value
+      end
+
       def primary_category=(value)
         value = prefix_apps(value)
         value = prefix_mzgenre(value)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
This PR enables the retrieval and submission of a custom EULA for an app.
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->
This PR enables the retrieval and submission of a custom EULA for an app. 
The custom license and the EULA text are retrieved among the other app details, and are submitted back to App Store Connect when the app details are saved.
<!-- Please describe in detail how you tested your changes. -->
Live testing.