### PR TITLE
feat: enable/disable sign-in-with-apple capability

### DIFF
--- a/spaceship/lib/spaceship/connect_api/model.rb
+++ b/spaceship/lib/spaceship/connect_api/model.rb
@@ -132,7 +132,7 @@ module Spaceship
               id == included_data["id"] && type == included_data["type"]
             end
 
-            inflate_model(relationship_data, included)
+            inflate_model(relationship_data, included) if relationship_data
           end
 
           # Map a hash or an array of data

--- a/spaceship/lib/spaceship/connect_api/provisioning/provisioning.rb
+++ b/spaceship/lib/spaceship/connect_api/provisioning/provisioning.rb
@@ -43,6 +43,84 @@ module Spaceship
         params = Client.instance.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
         Client.instance.get("profiles", params)
       end
+
+      #
+      # capabilities
+      #
+
+      def disable_bundle_id_capability(bundle_id_capability: nil)
+        # Safety check: you can't disable a capability that is already disable (Apple doesn't know idempotency)
+        Client.instance.delete("bundleIdCapabilities/#{bundle_id_capability}")
+      rescue Spaceship::UnexpectedResponse
+        return
+      end
+
+      def enable_bundle_id_capability(bundle_id_id: nil, attributes: {}, relationships: {})
+        body = {
+            data: {
+                type: "bundleIdCapabilities",
+                attributes: attributes,
+                relationships: relationships
+            }
+        }
+
+        Client.instance.post("bundleIdCapabilities", body)
+      end
+
+      def enable_sign_in_with_apple_primary(bundle_id_id: nil)
+        enable_sign_in_with_apple(bundle_id_id: bundle_id_id, consent_type: "PRIMARY_APP_CONSENT")
+      end
+
+      def enable_sign_in_with_apple_related(bundle_id_id: nil, related_bundle_id_id: nil)
+        association = {
+            key: "TIBURON_PRIMARY_BUNDLEID",
+            allowedInstances: "MULTIPLE",
+            relationshipName: "appConsentBundleId",
+            relationshipType: "bundleIds"
+        }
+        relationships = {
+            appConsentBundleId: {
+                data: {
+                    type: "bundleIds",
+                    id: related_bundle_id_id
+                }
+            }
+        }
+        enable_sign_in_with_apple(bundle_id_id: bundle_id_id, consent_type: "RELATED_APP_CONSENT", associations: [association], extra_relationships: relationships)
+      end
+
+      def disable_sign_in_with_apple(bundle_id_id: nil)
+        disable_bundle_id_capability(bundle_id_capability: "#{bundle_id_id}_APPLE_ID_AUTH")
+      end
+
+      # @private
+
+      def enable_sign_in_with_apple(bundle_id_id: nil, consent_type: nil, associations: nil, extra_relationships: {})
+        consent_options = {}
+        consent_options[:key] = consent_type
+        consent_options[:associations] = associations if associations
+
+        consent = {
+            key: "TIBURON_APP_CONSENT",
+            options: [consent_options]
+        }
+        settings = [consent]
+
+        attributes = {
+            capabilityType: "APPLE_ID_AUTH",
+            settings: settings
+        }
+        relationships = {
+            bundleId: {
+                data: {
+                    type: "bundleIds",
+                    id: bundle_id_id
+                }
+            }
+        }
+        relationships.update(extra_relationships) if extra_relationships
+        enable_bundle_id_capability(bundle_id_id: bundle_id_id, attributes: attributes, relationships: relationships)
+      end
     end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
This PR adds initial support to enable, disable, and configure bundle capabilities, and in particular _Sign In with Apple_.
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail. -->
Tis PR adds a couple of generic methods in **Spaceship::ConnectAPI::Provisioning** to support enabling and disabling bundle capabilities. In addition, it also adds a few specific methods to enable, disable, and configure the _Sign In with Apple_ functionality.
<!-- Please describe in detail how you tested your changes. -->

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
This feature must be tested live. It is based upon the public Apple Connect API, so it should with both username/password login and API token.
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->