### PR TITLE
feat: return in flight app store state

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/app.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app.rb
@@ -139,11 +139,7 @@ module Spaceship
       def reject_version_if_possible!(platform: nil)
         platform ||= Spaceship::ConnectAPI::Platform::IOS
         filter = {
-          appStoreState: [
-            Spaceship::ConnectAPI::AppStoreVersion::AppStoreState::PENDING_DEVELOPER_RELEASE,
-            Spaceship::ConnectAPI::AppStoreVersion::AppStoreState::IN_REVIEW,
-            Spaceship::ConnectAPI::AppStoreVersion::AppStoreState::WAITING_FOR_REVIEW
-          ].join(","),
+          appStoreState: Spaceship::ConnectAPI::AppStoreVersion::REJECTABLE_STATES.join(","),
           platform: platform
         }
 
@@ -202,15 +198,21 @@ module Spaceship
       def get_edit_app_store_version(platform: nil, includes: nil)
         platform ||= Spaceship::ConnectAPI::Platform::IOS
         filter = {
-          appStoreState: [
-            Spaceship::ConnectAPI::AppStoreVersion::AppStoreState::PREPARE_FOR_SUBMISSION,
-            Spaceship::ConnectAPI::AppStoreVersion::AppStoreState::DEVELOPER_REJECTED,
-            Spaceship::ConnectAPI::AppStoreVersion::AppStoreState::REJECTED,
-            Spaceship::ConnectAPI::AppStoreVersion::AppStoreState::METADATA_REJECTED,
-            Spaceship::ConnectAPI::AppStoreVersion::AppStoreState::WAITING_FOR_REVIEW,
-            Spaceship::ConnectAPI::AppStoreVersion::AppStoreState::INVALID_BINARY
-          ].join(","),
+          appStoreState: Spaceship::ConnectAPI::AppStoreVersion::EDITABLE_STATES.join(","),
           platform: platform
+        }
+
+        # Get the latest version
+        return get_app_store_versions(filter: filter, includes: includes)
+               .sort_by { |v| Gem::Version.new(v.version_string) }
+               .last
+      end
+
+      def get_in_flight_app_store_version(platform: nil, includes: nil)
+        platform ||= Spaceship::ConnectAPI::Platform::IOS
+        filter = {
+            appStoreState: Spaceship::ConnectAPI::AppStoreVersion::IN_FLIGHT_STATES.join(","),
+            platform: platform
         }
 
         # Get the latest version

--- a/spaceship/lib/spaceship/connect_api/models/app_store_version.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_store_version.rb
@@ -48,6 +48,26 @@ module Spaceship
         SCHEDULED = "SCHEDULED"
       end
 
+      EDITABLE_STATES = [
+        AppStoreState::PREPARE_FOR_SUBMISSION,
+        AppStoreState::DEVELOPER_REJECTED,
+        AppStoreState::REJECTED,
+        AppStoreState::METADATA_REJECTED,
+        AppStoreState::WAITING_FOR_REVIEW,
+        AppStoreState::INVALID_BINARY
+      ]
+
+      IN_FLIGHT_STATES = EDITABLE_STATES + [
+        AppStoreState::IN_REVIEW,
+        AppStoreState::PENDING_DEVELOPER_RELEASE
+      ]
+
+      REJECTABLE_STATES = [
+        AppStoreState::WAITING_FOR_REVIEW,
+        AppStoreState::IN_REVIEW,
+        AppStoreState::PENDING_DEVELOPER_RELEASE
+      ]
+
       attr_mapping({
         "platform" =>  "platform",
         "versionString" =>  "version_string",


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The new fastlane implementation to retrieve the editable version no longer returns the app version in review or pending developer release. For compatibility, we add a new method to retrieve the in flight version as a superset of the editable version.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
This PR adds a new method to retrieve the in flight method.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
Live testing on the bunker