### PR TITLE
[spaceship] Add check for validation error and handle it

### DIFF
--- a/spaceship/lib/spaceship.rb
+++ b/spaceship/lib/spaceship.rb
@@ -15,6 +15,8 @@ require_relative 'spaceship/test_flight'
 require_relative 'spaceship/connect_api'
 require_relative 'spaceship/spaceauth_runner'
 
+require_relative 'spaceship/utils'
+
 require_relative 'spaceship/module'
 
 # Support for legacy wrappers

--- a/spaceship/lib/spaceship/connect_api/models/app_screenshot.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_screenshot.rb
@@ -21,7 +21,7 @@ module Spaceship
       attr_accessor :asset_delivery_state
       attr_accessor :uploaded
 
-      MAX_CREATE_RETRIES = 10
+      INITIAL_REMAINING_TRIES = 10
 
       attr_mapping({
         "fileSize" => "file_size",
@@ -82,31 +82,26 @@ module Spaceship
       #
       #
 
-      def delete!(filter: {}, includes: nil, limit: nil, sort: nil)
-        Spaceship::ConnectAPI.delete_app_screenshot(app_screenshot_id: id)
-      end
-
       def self.create(app_screenshot_set_id: nil, path: nil, wait_for_processing: true)
         success = false
-        try_number = 1
+        remaining_tries = INITIAL_REMAINING_TRIES
 
         until success
           begin
-            self.private_create(app_screenshot_set_id: app_screenshot_set_id, path: path, wait_for_processing: wait_for_processing)
+            private_create(app_screenshot_set_id: app_screenshot_set_id, path: path, wait_for_processing: wait_for_processing)
             success = true
           rescue Spaceship::ValidationJobFailedError => e
-            raise e unless try_number < MAX_CREATE_RETRIES
-
-            screenshot = e.screenshot
+            remaining_tries -= 1
+            raise e unless remaining_tries > 0
 
             # try to delete; if it does not exist, retry_api_call will handle the resource not found error
-            Spaceship.retry_api_call do
-              screenshot.delete!
-            end
-
-            try_number += 1
+            Spaceship.retry_api_call { e.screenshot.delete! }
           end
         end
+      end
+
+      def delete!(filter: {}, includes: nil, limit: nil, sort: nil)
+        Spaceship::ConnectAPI.delete_app_screenshot(app_screenshot_id: id)
       end
 
       private_class_method

--- a/spaceship/lib/spaceship/connect_api/models/app_screenshot.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_screenshot.rb
@@ -97,11 +97,7 @@ module Spaceship
           rescue Spaceship::ValidationJobFailedError => e
             raise e unless try_number < MAX_CREATE_RETRIES
 
-            # find the screenshot for which the private create failed
-            screenshots = Spaceship::ConnectAPI::AppScreenshotSet
-                          .get(app_screenshot_set_id: app_screenshot_set_id)
-                          .app_screenshots
-            screenshot = screenshots.find(&:error?)
+            screenshot = e.screenshot
 
             # try to delete; if it does not exist, retry_api_call will handle the resource not found error
             Spaceship.retry_api_call do
@@ -201,7 +197,7 @@ module Spaceship
               error_message = messages.join(". ")
 
               if error_message =~ /VALIDATION_JOB_FAILED/
-                raise Spaceship::ValidationJobFailedError
+                raise Spaceship::ValidationJobFailedError.new(error_message, screenshot)
               else
                 raise error_message
               end

--- a/spaceship/lib/spaceship/connect_api/models/app_screenshot.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_screenshot.rb
@@ -1,6 +1,7 @@
 require_relative '../model'
 require_relative '../file_uploader'
 require_relative './app_screenshot_set'
+require_relative '../../errors'
 require 'spaceship/globals'
 
 require 'digest/md5'
@@ -19,6 +20,8 @@ module Spaceship
       attr_accessor :upload_operations
       attr_accessor :asset_delivery_state
       attr_accessor :uploaded
+
+      MAX_CREATE_RETRIES = 10
 
       attr_mapping({
         "fileSize" => "file_size",
@@ -79,7 +82,40 @@ module Spaceship
       #
       #
 
+      def delete!(filter: {}, includes: nil, limit: nil, sort: nil)
+        Spaceship::ConnectAPI.delete_app_screenshot(app_screenshot_id: id)
+      end
+
       def self.create(app_screenshot_set_id: nil, path: nil, wait_for_processing: true)
+        success = false
+        try_number = 1
+
+        until success
+          begin
+            self.private_create(app_screenshot_set_id: app_screenshot_set_id, path: path, wait_for_processing: wait_for_processing)
+            success = true
+          rescue Spaceship::ValidationJobFailedError => e
+            raise e unless try_number < MAX_CREATE_RETRIES
+
+            # find the screenshot for which the private create failed
+            screenshots = Spaceship::ConnectAPI::AppScreenshotSet
+                          .get(app_screenshot_set_id: app_screenshot_set_id)
+                          .app_screenshots
+            screenshot = screenshots.find(&:error?)
+
+            # try to delete; if it does not exist, retry_api_call will handle the resource not found error
+            Spaceship.retry_api_call do
+              screenshot.delete!
+            end
+
+            try_number += 1
+          end
+        end
+      end
+
+      private_class_method
+
+      def self.private_create(app_screenshot_set_id: nil, path: nil, wait_for_processing: true)
         require 'faraday'
 
         filename = File.basename(path)
@@ -162,7 +198,13 @@ module Spaceship
               break
             elsif screenshot.error?
               messages = ["Error processing screenshot '#{screenshot.file_name}'"] + screenshot.error_messages
-              raise messages.join(". ")
+              error_message = messages.join(". ")
+
+              if error_message =~ /VALIDATION_JOB_FAILED/
+                raise Spaceship::ValidationJobFailedError
+              else
+                raise error_message
+              end
             end
 
             # Poll every 2 seconds
@@ -175,10 +217,6 @@ module Spaceship
         end
 
         return screenshot
-      end
-
-      def delete!(filter: {}, includes: nil, limit: nil, sort: nil)
-        Spaceship::ConnectAPI.delete_app_screenshot(app_screenshot_id: id)
       end
     end
   end

--- a/spaceship/lib/spaceship/errors.rb
+++ b/spaceship/lib/spaceship/errors.rb
@@ -79,4 +79,7 @@ module Spaceship
 
   # Raised when 403 is received from portal request
   class AccessForbiddenError < BasicPreferredInfoError; end
+
+  # Raised when a "VALIDATION_JOB_FAILED" message is received during screenshot upload
+  class ValidationJobFailedError < BasicPreferredInfoError; end
 end

--- a/spaceship/lib/spaceship/errors.rb
+++ b/spaceship/lib/spaceship/errors.rb
@@ -81,5 +81,12 @@ module Spaceship
   class AccessForbiddenError < BasicPreferredInfoError; end
 
   # Raised when a "VALIDATION_JOB_FAILED" message is received during screenshot upload
-  class ValidationJobFailedError < BasicPreferredInfoError; end
+  class ValidationJobFailedError < BasicPreferredInfoError
+    attr_reader :screenshot
+
+    def initialize(error_message = nil, screenshot = nil)
+      @screenshot = screenshot
+      super(error_message)
+    end
+  end
 end

--- a/spaceship/lib/spaceship/utils.rb
+++ b/spaceship/lib/spaceship/utils.rb
@@ -1,0 +1,33 @@
+require 'spaceship/tunes/tunes'
+
+require_relative 'module'
+
+module Spaceship
+  MAX_RETRIES = 10
+
+  def self.retry_api_call
+    success = false
+    try_number = 0
+
+    until success
+      begin
+        yield
+        success = true
+      rescue Spaceship::InternalServerError, Faraday::ConnectionFailed => e
+        # BSP: We're not quite sure of what's causing the 500/504 errors, possibly a server issue. To avoid the
+        # complete failure of the upload, we retry and hope for the best
+        try_number += 1
+
+        raise Spaceship::TunesClient::ITunesConnectPotentialServerError.new, "Number of retries exceeded, aborting." if try_number > MAX_RETRIES
+      rescue Spaceship::UnexpectedResponse => e
+        # If we get this error, it means the previous deletion operation completed successfully and must not be
+        # attempted again. We never get this on a failed creation.
+        if e.message =~ /The specified resource does not exist/
+          success = true
+        else
+          raise e
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Screenshot uploads sometimes fail due to a `VALIDATION_JOB_FAILED` error. Currently we do not handle it and this causes:
- The whole workflow of metadata uploading to fail.
- A grey screenshot to appear in place of the failed one.

### Description
In this PR, we recognise when said error is returned. Since it is usually a random failure and the screenshot is, in fact, valid, a retry will be performed. Before the retry is done, the screenshot for which the error has been returned is deleted.

### Testing Steps
- [x] Test live on bunker
