### PR TITLE
[spaceship] Add support for EULA management (bsp fork)

### DIFF
--- a/spaceship/lib/spaceship/connect_api.rb
+++ b/spaceship/lib/spaceship/connect_api.rb
@@ -54,6 +54,7 @@ require 'spaceship/connect_api/models/idfa_declaration'
 require 'spaceship/connect_api/models/reset_ratings_request'
 require 'spaceship/connect_api/models/sandbox_tester'
 require 'spaceship/connect_api/models/territory'
+require 'spaceship/connect_api/models/end_user_license_agreement'
 
 module Spaceship
   class ConnectAPI

--- a/spaceship/lib/spaceship/connect_api/models/app.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app.rb
@@ -1,5 +1,6 @@
 require_relative '../model'
 require_relative './build'
+require_relative './end_user_license_agreement'
 
 module Spaceship
   class ConnectAPI
@@ -309,6 +310,21 @@ module Spaceship
       def update_beta_group(beta_group, public_link_enabled: nil, public_link_limit: nil, public_link_limit_enabled: nil)
         resps = Spaceship::ConnectAPI.update_beta_group(beta_group.id, public_link_enabled: public_link_enabled, public_link_limit: public_link_limit, public_link_limit_enabled: public_link_limit_enabled)
         Spaceship::ConnectAPI::Models.parse(resps.body)
+      end
+
+      #
+      # End User License Agreements
+      #
+
+      def create_end_user_license_agreement(attributes, territory_ids: nil)
+        attributes = Spaceship::ConnectAPI::EndUserLicenseAgreement.reverse_attr_mapping(attributes)
+        resp = Spaceship::ConnectAPI.post_end_user_license_agreement(app_id: id, attributes: attributes, territory_ids: territory_ids)
+        return resp.to_models.first
+      end
+
+      def fetch_end_user_license_agreement
+        resp = Spaceship::ConnectAPI.get_end_user_license_agreement(app_id: id)
+        return resp.to_models.first
       end
 
       #

--- a/spaceship/lib/spaceship/connect_api/models/end_user_license_agreement.rb
+++ b/spaceship/lib/spaceship/connect_api/models/end_user_license_agreement.rb
@@ -1,0 +1,36 @@
+require_relative '../model'
+module Spaceship
+  class ConnectAPI
+    class EndUserLicenseAgreement
+      include Spaceship::ConnectAPI::Model
+
+      attr_accessor :agreement_text
+
+      attr_mapping({
+        "agreementText" => "agreement_text"
+      })
+
+      def self.type
+        return "endUserLicenseAgreements"
+      end
+
+      #
+      # API
+      #
+
+      def fetch_territories
+        resp = Spaceship::ConnectAPI.get_eula_territories(end_user_license_agreement_id: id)
+        return resp.to_models
+      end
+
+      def update(attributes: nil, territory_ids: nil)
+        attributes = reverse_attr_mapping(attributes)
+        Spaceship::ConnectAPI.patch_end_user_license_agreement(end_user_license_agreement_id: id, attributes: attributes, territory_ids: territory_ids)
+      end
+
+      def delete!
+        Spaceship::ConnectAPI.delete_end_user_license_agreement(end_user_license_agreement_id: id)
+      end
+    end
+  end
+end

--- a/spaceship/lib/spaceship/connect_api/models/territory.rb
+++ b/spaceship/lib/spaceship/connect_api/models/territory.rb
@@ -22,6 +22,11 @@ module Spaceship
         resps = Spaceship::ConnectAPI.get_territories(filter: {}, includes: nil, limit: nil, sort: nil).all_pages
         return resps.flat_map(&:to_models)
       end
+
+      def self.for_eula(end_user_license_agreement_id: nil)
+        resps = Spaceship::ConnectAPI.get_eula_territories(end_user_license_agreement_id: end_user_license_agreement_id).all_pages
+        return resps.flat_map(&:to_models)
+      end
     end
   end
 end

--- a/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
@@ -898,6 +898,71 @@ module Spaceship
       end
 
       #
+      # endUserLicenseAgreements
+      #
+
+      def get_end_user_license_agreement(app_id: nil)
+        params = Client.instance.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
+        Client.instance.get("apps/#{app_id}/endUserLicenseAgreement", params)
+      end
+
+      def post_end_user_license_agreement(app_id: nil, attributes: nil, territory_ids: nil)
+        territories_data = territory_ids.map do |id|
+          { type: "territories", id: id }
+        end
+
+        relationships = {
+          app: {
+            data: {
+                type: "apps",
+                id: app_id
+            }
+          },
+          territories: {
+            data: territories_data
+          }
+        }
+
+        body = {
+            data: {
+                type: "endUserLicenseAgreements",
+                attributes: attributes,
+                relationships: relationships
+            }
+        }
+
+        Client.instance.post("endUserLicenseAgreements", body)
+      end
+
+      def patch_end_user_license_agreement(end_user_license_agreement_id: nil, attributes: nil, territory_ids: nil)
+        territories_data = territory_ids.map do |id|
+          { type: "territories", id: id }
+        end
+
+        relationships = {
+          territories: {
+            data: territories_data
+          }
+        }
+
+        body = {
+            data: {
+                type: "endUserLicenseAgreements",
+                id: end_user_license_agreement_id,
+                attributes: attributes,
+                relationships: relationships
+            }
+        }
+
+        Client.instance.patch("endUserLicenseAgreements/#{end_user_license_agreement_id}", body)
+      end
+
+      def delete_end_user_license_agreement(end_user_license_agreement_id: nil)
+        params = Client.instance.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
+        Client.instance.delete("endUserLicenseAgreements/#{end_user_license_agreement_id}", params)
+      end
+
+      #
       # sandboxTesters
       #
 
@@ -929,6 +994,11 @@ module Spaceship
       def get_territories(filter: {}, includes: nil, limit: nil, sort: nil)
         params = Client.instance.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
         Client.instance.get("territories", params)
+      end
+
+      def get_eula_territories(end_user_license_agreement_id: nil)
+        params = Client.instance.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
+        Client.instance.get("endUserLicenseAgreements/#{end_user_license_agreement_id}/territories", params)
       end
     end
   end

--- a/spaceship/spec/connect_api/fixtures/tunes/end_user_license_agreement.json
+++ b/spaceship/spec/connect_api/fixtures/tunes/end_user_license_agreement.json
@@ -1,0 +1,29 @@
+{
+    "data" : {
+      "type" : "endUserLicenseAgreements",
+      "id" : "123456789",
+      "attributes" : {
+        "agreementText": "FastlaneTest"
+      },
+      "relationships" : {
+        "app" : {
+          "links" : {
+            "self" : "https://appstoreconnect.apple.com/iris/v1/endUserLicenseAgreements/123456789/relationships/app",
+            "related" : "https://appstoreconnect.apple.com/iris/v1/endUserLicenseAgreements/123456789/app"
+          }
+        },
+        "territories" : {
+          "links" : {
+            "self" : "https://appstoreconnect.apple.com/iris/v1/endUserLicenseAgreements/123456789/relationships/territories",
+            "related" : "https://appstoreconnect.apple.com/iris/v1/endUserLicenseAgreements/123456789/territories"
+          }
+        }
+      },
+      "links" : {
+        "self" : "https://appstoreconnect.apple.com/iris/v1/endUserLicenseAgreements/123456789"
+      }
+    },
+    "links" : {
+      "self" : "https://appstoreconnect.apple.com/iris/v1/endUserLicenseAgreements"
+    }
+  }

--- a/spaceship/spec/connect_api/tunes/tunes_client_spec.rb
+++ b/spaceship/spec/connect_api/tunes/tunes_client_spec.rb
@@ -67,5 +67,19 @@ describe Spaceship::ConnectAPI::Tunes::Client do
         end
       end
     end
+
+    describe "endUserLicenseAgreement" do
+      context 'get_end_user_license_agreement' do
+        app_id = "123"
+        let(:path) { "apps/#{app_id}/endUserLicenseAgreement" }
+
+        it 'succeeds' do
+          params = {}
+          req_mock = test_request_params(path, params)
+          expect(client).to receive(:request).with(:get).and_yield(req_mock)
+          Spaceship::ConnectAPI.get_end_user_license_agreement(app_id: app_id)
+        end
+      end
+    end
   end
 end

--- a/spaceship/spec/connect_api/tunes/tunes_stubbing.rb
+++ b/spaceship/spec/connect_api/tunes/tunes_stubbing.rb
@@ -18,6 +18,11 @@ class ConnectAPIStubbing
         stub_request(:post, "https://appstoreconnect.apple.com/iris/v1/appStoreVersionReleaseRequests").
           to_return(status: 200, body: read_fixture_file('app_store_version_release_request.json'), headers: { 'Content-Type' => 'application/json' })
       end
+
+      def stub_get_end_user_license_agreement
+        stub_request(:get, "https://appstoreconnect.apple.com/iris/v1/apps/123/endUserLicenseAgreement").
+          to_return(status: 200, body: read_fixture_file('end_user_license_agreement.json'), headers: { 'Content-Type' => 'application/json' })
+      end
     end
   end
 end

--- a/spaceship/spec/spec_helper.rb
+++ b/spaceship/spec/spec_helper.rb
@@ -91,6 +91,7 @@ def before_each_spaceship
   ConnectAPIStubbing::TestFlight.stub_pre_release_versions
 
   ConnectAPIStubbing::Tunes.stub_app_store_version_release_request
+  ConnectAPIStubbing::Tunes.stub_get_end_user_license_agreement
 
   ConnectAPIStubbing::Users.stub_users
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR introduces support for the `endUserLicenseAgreement` App Store Connect resource.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
A new `EndUserLicenseAgreement` class has been added, with helper methods to retrieve, delete, and update an existing Eula. Both the text and the territories can be changed. An helper method to retrieve the territories associated with a given Eula has also been added.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
All new methods have been tested on a live infrastructure. In addition, the Eula retrieval method also has a dedicated spec.