### PR TITLE
[Fix] Remove usage of legacy app during app previews upload

### DIFF
--- a/deliver/lib/deliver/upload_app_previews.rb
+++ b/deliver/lib/deliver/upload_app_previews.rb
@@ -14,9 +14,7 @@ module Deliver
       return if options[:skip_app_previews]
       return if options[:edit_live]
 
-      legacy_app = options[:app]
-      app_id = legacy_app.apple_id
-      app = Spaceship::ConnectAPI::App.get(app_id: app_id)
+      app = options[:app]
 
       platform = Spaceship::ConnectAPI::Platform.map(options[:platform])
       version = app.get_edit_app_store_version(platform: platform)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
When we performed the rebase from Fastlane on Monday, one of the things we replaced was the usage of `legacy_app` that whose ID would be used to fetch the app from Apple (we do it in Bunker by ourselves now). However, we did not take into account the previews section as that part was added by us and is not present in Fastlane.

### Description
In this small PR, we just move the logic in the rest of the metadata uploading to app previews uploading regarding fetching the app.

### Testing Steps
Ran the tests, I guess
