### PR TITLE
[deliver] Fix: appScreenshotSets doesn't exist handling

### DIFF
--- a/deliver/lib/deliver/utils.rb
+++ b/deliver/lib/deliver/utils.rb
@@ -25,9 +25,14 @@ module Deliver
         # attempted again. We never get this on a failed creation.
         if e.message =~ /The specified resource does not exist/
           success = true
+        elsif e.message =~ /appScreenshotSets doesn't exist/
+          UI.error("Error while interacting with App Store Connect API, making a new attempt. Error: #{e.message}. Counter: #{try_number}")
+          try_number += 1
         else
           raise e
         end
+
+        raise Spaceship::TunesClient::ITunesConnectPotentialServerError.new, "Number of retries exceeded, aborting." if try_number > MAX_RETRIES
       end
     end
   end

--- a/spaceship/lib/spaceship/connect_api/models/app_screenshot.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_screenshot.rb
@@ -1,5 +1,6 @@
 require_relative '../model'
 require_relative '../file_uploader'
+require_relative '../../errors'
 require_relative './app_screenshot_set'
 require 'spaceship/globals'
 
@@ -97,7 +98,7 @@ module Spaceship
             app_screenshot_set_id: app_screenshot_set_id,
             attributes: post_attributes
           ).first
-        rescue => error
+        rescue InternalServerError => error
           # Sometimes creating a screenshot with the web session App Store Connect API
           # will result in a false failure. The response will return a 503 but the database
           # insert will eventually go through.


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR handles a regression recently introduced by fastlane which prevents temporary errors of the form `The provided entity includes a relationship with an invalid value - appScreenshotSets doesn't exist!!` from being fixed by a retry, due to them being erroneously caught by a rescue handler which is instead supposed to rescue only 5xx-6xx errors.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
The error handler has been modified to rescue only 5xx errors, which should be fine since it expected a 503 anyway. The screenshot upload block was already surrounded by a `retry_api_call` method, which now also takes care of "ignoring" errors related to `appScreenshotSets` not existing. If this works, we can think of a way to push the change to upstream fastlane without the `retry_api_call` method.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
To be tested live on the bunker.