### PR TITLE
[spaceship] Make preview uploads more robust

### DIFF
--- a/deliver/lib/deliver/upload_app_previews.rb
+++ b/deliver/lib/deliver/upload_app_previews.rb
@@ -111,20 +111,20 @@ module Deliver
       # Check if should wait for processing
       # Default to waiting if submitting for review (since needed for submission)
       # Otherwise use enviroment variable
-      if ENV["DELIVER_SKIP_WAIT_FOR_SCREENSHOT_PROCESSING"].nil?
+      if ENV["DELIVER_SKIP_WAIT_FOR_PREVIEW_PROCESSING"].nil?
         wait_for_processing = options[:submit_for_review]
         UI.verbose("Setting wait_for_processing from ':submit_for_review' option")
       else
-        UI.verbose("Setting wait_for_processing from 'DELIVER_SKIP_WAIT_FOR_SCREENSHOT_PROCESSING' environment variable")
-        wait_for_processing = !FastlaneCore::Env.truthy?("DELIVER_SKIP_WAIT_FOR_SCREENSHOT_PROCESSING")
+        UI.verbose("Setting wait_for_processing from 'DELIVER_SKIP_WAIT_FOR_PREVIEW_PROCESSING' environment variable")
+        wait_for_processing = !FastlaneCore::Env.truthy?("DELIVER_SKIP_WAIT_FOR_PREVIEW_PROCESSING")
       end
 
       if wait_for_processing
-        UI.important("Will wait for screenshot image processing")
-        UI.important("Set env DELIVER_SKIP_WAIT_FOR_SCREENSHOT_PROCESSING=true to skip waiting for screenshots to process")
+        UI.important("Will wait for preview video processing")
+        UI.important("Set env DELIVER_SKIP_WAIT_FOR_PREVIEW_PROCESSING=true to skip waiting for previews to process")
       else
-        UI.important("Skipping the wait for screenshot image processing (which may affect submission)")
-        UI.important("Set env DELIVER_SKIP_WAIT_FOR_SCREENSHOT_PROCESSING=false to wait for screenshots to process")
+        UI.important("Skipping the wait for preview video processing (which may affect submission)")
+        UI.important("Set env DELIVER_SKIP_WAIT_FOR_PREVIEW_PROCESSING=false to wait for previews to process")
       end
 
       frame_time_code = options[:frame_time_code]

--- a/spaceship/lib/spaceship/connect_api/models/app_preview.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_preview.rb
@@ -93,7 +93,7 @@ module Spaceship
           # The equivalent for the screenshots: https://github.com/fastlane/fastlane/pull/16842
           time = Time.now.to_i
 
-          timeout_minutes = (ENV["SPACESHIP_SCREENSHOT_UPLOAD_TIMEOUT"] || 20).to_i
+          timeout_minutes = (ENV["SPACESHIP_PREVIEW_UPLOAD_TIMEOUT"] || 20).to_i
 
           loop do
             puts("Waiting for preview to appear before uploading...")

--- a/spaceship/lib/spaceship/connect_api/models/app_preview.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_preview.rb
@@ -83,14 +83,14 @@ module Spaceship
             attributes: post_attributes
           ).first
         rescue Spaceship::InternalServerError => error
-          # Sometimes creating a screenshot with the web session App Store Connect API
+          # Sometimes creating a preview with the web session App Store Connect API
           # will result in a false failure. The response will return a 503 but the database
           # insert will eventually go through.
           #
-          # When this is observed, we will poll until we find the matchin screenshot that
+          # When this is observed, we will poll until we find the matching preview that
           # is awaiting for upload and file size
           #
-          # https://github.com/fastlane/fastlane/pull/16842
+          # The equivalent for the screenshots: https://github.com/fastlane/fastlane/pull/16842
           time = Time.now.to_i
 
           timeout_minutes = (ENV["SPACESHIP_SCREENSHOT_UPLOAD_TIMEOUT"] || 20).to_i


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fastlane has introduced a fix for the issues when a screenshot is not deleted but Apple says it is and when a screenshot is uploaded successfully but Apple says it isn't (see [here](https://github.com/fastlane/fastlane/pull/16842)). We want to have the same logic in the previews workflow that was added by us.

### Description
We add the same logic:
- Check if all previews have been deleted after a deletion by counting them.
- Poll if a 503 error is received to see whether the created preview exists.

### Testing Steps
Ran tests
