### PR TITLE
[spaceship] Fix app store version localizations api

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/app_preview_set.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_preview_set.rb
@@ -58,11 +58,6 @@ module Spaceship
       # API
       #
 
-      def self.all(filter: {}, includes: nil, limit: nil, sort: nil)
-        resp = Spaceship::ConnectAPI.get_app_preview_sets(filter: filter, includes: includes, limit: limit, sort: sort)
-        return resp.to_models
-      end
-
       def self.get(app_preview_set_id: nil, includes: "appPreviews")
         return Spaceship::ConnectAPI.get_app_preview_set(app_preview_set_id: app_preview_set_id, filter: nil, includes: includes, limit: nil, sort: nil).first
       end

--- a/spaceship/lib/spaceship/connect_api/models/app_screenshot_set.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_screenshot_set.rb
@@ -112,11 +112,6 @@ module Spaceship
       # API
       #
 
-      def self.all(filter: {}, includes: nil, limit: nil, sort: nil)
-        resp = Spaceship::ConnectAPI.get_app_screenshot_sets(filter: filter, includes: includes, limit: limit, sort: sort)
-        return resp.to_models
-      end
-
       def self.get(app_screenshot_set_id: nil, includes: "appScreenshots")
         return Spaceship::ConnectAPI.get_app_screenshot_set(app_screenshot_set_id: app_screenshot_set_id, filter: nil, includes: includes, limit: nil, sort: nil).first
       end

--- a/spaceship/lib/spaceship/connect_api/models/app_store_version.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_store_version.rb
@@ -135,11 +135,9 @@ module Spaceship
         return resp.to_models.first
       end
 
-      # appScreenshotSets,appPreviewSets
-      def get_app_store_version_localizations(filter: {}, includes: "appScreenshotSets", limit: nil, sort: nil)
-        filter ||= {}
-        filter["appStoreVersion"] = id
-        return Spaceship::ConnectAPI::AppStoreVersionLocalization.all(filter: filter, includes: includes, limit: limit, sort: sort)
+      def get_app_store_version_localizations(limit: nil)
+        resp = Spaceship::ConnectAPI.get_app_store_version_localizations(app_store_version_id: id, limit: limit)
+        return resp.to_models
       end
 
       #

--- a/spaceship/lib/spaceship/connect_api/models/app_store_version_localization.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_store_version_localization.rb
@@ -15,9 +15,6 @@ module Spaceship
       attr_accessor :support_url
       attr_accessor :whats_new
 
-      attr_accessor :app_screenshot_sets
-      attr_accessor :app_preview_sets
-
       attr_mapping({
         "description" =>  "description",
         "locale" =>  "locale",
@@ -25,10 +22,7 @@ module Spaceship
         "marketingUrl" =>  "marketing_url",
         "promotionalText" =>  "promotional_text",
         "supportUrl" =>  "support_url",
-        "whatsNew" =>  "whats_new",
-
-        "appScreenshotSets" =>  "app_screenshot_sets",
-        "appPreviewSets" =>  "app_preview_sets"
+        "whatsNew" =>  "whats_new"
       })
 
       def self.type
@@ -38,11 +32,6 @@ module Spaceship
       #
       # API
       #
-
-      def self.all(filter: {}, includes: nil, limit: nil, sort: nil)
-        resp = Spaceship::ConnectAPI.get_app_store_version_localizations(filter: filter, includes: includes, limit: limit, sort: sort)
-        return resp.to_models
-      end
 
       def update(attributes: nil)
         attributes = reverse_attr_mapping(attributes)
@@ -58,9 +47,8 @@ module Spaceship
       #
 
       def get_app_preview_sets(filter: {}, includes: "appPreviews", limit: nil, sort: nil)
-        filter ||= {}
-        filter["appStoreVersionLocalization"] = id
-        return Spaceship::ConnectAPI::AppPreviewSet.all(filter: filter, includes: includes, limit: limit, sort: sort)
+        resp = Spaceship::ConnectAPI.get_app_preview_sets(app_store_version_localization_id: id, filter: filter, includes: includes, limit: limit, sort: sort)
+        return resp.to_models
       end
 
       def create_app_preview_set(attributes: nil)
@@ -73,9 +61,8 @@ module Spaceship
       #
 
       def get_app_screenshot_sets(filter: {}, includes: "appScreenshots", limit: nil, sort: nil)
-        filter ||= {}
-        filter["appStoreVersionLocalization"] = id
-        return Spaceship::ConnectAPI::AppScreenshotSet.all(filter: filter, includes: includes, limit: limit, sort: sort)
+        resp = Spaceship::ConnectAPI.get_app_screenshot_sets(app_store_version_localization_id: id, filter: filter, includes: includes, limit: limit, sort: sort)
+        return resp.to_models
       end
 
       def create_app_screenshot_set(attributes: nil)

--- a/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
@@ -236,9 +236,9 @@ module Spaceship
       # appPreviewSets
       #
 
-      def get_app_preview_sets(filter: {}, includes: nil, limit: nil, sort: nil)
+      def get_app_preview_sets(app_store_version_localization_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
         params = Client.instance.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-        Client.instance.get("appPreviewSets", params)
+        Client.instance.get("appStoreVersionLocalizations/#{app_store_version_localization_id}/appPreviewSets", params)
       end
 
       def get_app_preview_set(app_preview_set_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
@@ -342,9 +342,9 @@ module Spaceship
       # appScreenshotSets
       #
 
-      def get_app_screenshot_sets(filter: {}, includes: nil, limit: nil, sort: nil)
+      def get_app_screenshot_sets(app_store_version_localization_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
         params = Client.instance.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-        Client.instance.get("appScreenshotSets", params)
+        Client.instance.get("appStoreVersionLocalizations/#{app_store_version_localization_id}/appScreenshotSets", params)
       end
 
       def get_app_screenshot_set(app_screenshot_set_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
@@ -623,9 +623,9 @@ module Spaceship
       # appStoreVersionLocalizations
       #
 
-      def get_app_store_version_localizations(filter: {}, includes: nil, limit: nil, sort: nil)
-        params = Client.instance.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-        Client.instance.get("appStoreVersionLocalizations", params)
+      def get_app_store_version_localizations(app_store_version_id: nil, limit: nil)
+        params = Client.instance.build_params(filter: nil, includes: nil, limit: limit, sort: nil)
+        Client.instance.get("appStoreVersions/#{app_store_version_id}/appStoreVersionLocalizations", params)
       end
 
       def post_app_store_version_localization(app_store_version_id: nil, attributes: {})


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Apple deprecated the private API that was previously used to fetch app localisations, screenshot sets and preview sets by dropping support for the `GET_COLLECTION` method. Calling the old endpoints produces an error of the following form:

- **status**: "403"
- **code**: "FORBIDDEN_ERROR"
- **title**: "The given operation is not allowed"
- **detail**: "The resource 'appStoreVersionLocalizations' does not allow 'GET_COLLECTION'. Allowed operations are: GET_INSTANCE, CREATE, UPDATE, DELETE"}]

Therefore, fetching this data requires to call new public endpoints for [appStoreVersionLocalizations](https://developer.apple.com/documentation/appstoreconnectapi/list_all_app_store_version_localizations_for_an_app_store_version), [appScreenshotSets](https://developer.apple.com/documentation/appstoreconnectapi/list_all_app_screenshot_sets_for_an_app_store_version_localization) and [appPreviewSets](https://developer.apple.com/documentation/appstoreconnectapi/list_all_app_preview_sets_for_an_app_store_version_localization).

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
This PR updates the ConnectAPI methods exposed by fastlane for `appStoreVersionLocalizations`, `appScreenshotSets` and `appPreviewSets` to rely on the public endpoints of the App Store Connect API instead. These endpoints can be transparently called both with the new token-based authentication and with the legacy web credentials authentication.

Due to the different nature of the endpoints, some accessor methods like `all` had to be removed from some of the classes.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
Tested live with a local bunker.

### TODO
Consider pushing these changes to the main upstream repository.