### PR TITLE
[deliver] Upload only media that has changed

### DIFF
--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -221,8 +221,8 @@ module Deliver
 
           # Skip if there are no checksums for the specified locale and device type
           next unless checksums_for_locale.keys.include?(device_type)
-          checksums_for_device_type = checksums_for_locale[device_type]
-          UI.message("Removing specified screenshots for '#{localization.locale}' '#{device_type}'...")
+          checksums_for_device_type = checksums_for_locale[device_type][:checksums]
+          UI.message("Removing #{checksums_for_device_type.size} screenshots for '#{localization.locale}' '#{device_type}'...")
 
           screenshot_set.app_screenshots.each do |screenshot|
             next unless checksums_for_device_type.include?(screenshot.source_file_checksum)

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -316,7 +316,7 @@ module Deliver
         end
 
         screenshots_per_device_type.each do |device_type, screenshots_with_positions|
-          UI.message("Uploading #{screenshots_with_positions.length} screenshots for language #{language}")
+          UI.message("Uploading #{screenshots_with_positions.length} screenshots for '#{language}', '#{device_type}'")
           screenshots_with_positions.each do |screenshot_with_position|
             screenshot = screenshot_with_position[:screenshot]
 

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -243,10 +243,10 @@ module Deliver
           app_store_screenshot_set.app_screenshots.each do |app_store_screenshot|
             next unless ids_to_delete.include?(app_store_screenshot.id)
 
-            UI.verbose("Deleting screenshot - #{language} #{app_store_screenshot_set.screenshot_display_type} #{app_store_screenshot.id}")
+            UI.message("Deleting screenshot - #{language} #{app_store_screenshot_set.screenshot_display_type} #{app_store_screenshot.id}")
             Deliver.retry_api_call do
               app_store_screenshot.delete!
-              UI.verbose("Deleted screenshot - #{language} #{app_store_screenshot_set.screenshot_display_type} #{app_store_screenshot.id}")
+              UI.message("Deleted screenshot - #{language} #{app_store_screenshot_set.screenshot_display_type} #{app_store_screenshot.id}")
             end
           end
         end
@@ -325,8 +325,10 @@ module Deliver
         app_store_sets_for_language = app_store_screenshot_sets_map[language]
 
         changed_sets_per_device_type.each do |device_type, changed_screenshots_for_device_type|
-          UI.message("Uploading #{changed_screenshots_for_device_type.length} screenshots for '#{language}', '#{device_type}'")
-          changed_screenshots_for_device_type.each do |changed_screenshot_with_position|
+          changed_screenshots_to_be_uploaded = changed_screenshots_for_device_type.reject { |screenshot_with_position| screenshot_with_position[:screenshot].nil? }
+          UI.message("Uploading #{changed_screenshots_to_be_uploaded.length} screenshots for '#{language}', '#{device_type}'")
+
+          changed_screenshots_to_be_uploaded.each do |changed_screenshot_with_position|
             changed_screenshot = changed_screenshot_with_position[:screenshot]
 
             # don't upload the empty screenshots that represent the no-longer filled positions

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -305,10 +305,11 @@ module Deliver
           app_screenshot_sets_map[app_screenshot_set.screenshot_display_type] = app_screenshot_set
         end
 
-        screenshots_per_device_type.each do |device_type, screenshots_with_checksums|
-          UI.message("Uploading #{screenshots_with_checksums.length} screenshots for language #{language}")
-          screenshots_with_checksums.each do |screenshot_with_checksum|
-            screenshot = screenshot_with_checksum[:screenshot]
+        screenshots_per_device_type.each do |device_type, screenshots_with_positions|
+          UI.message("Uploading #{screenshots_with_positions.length} screenshots for language #{language}")
+          screenshots_with_positions.each do |screenshot_with_position|
+            screenshot = screenshot_with_position[:screenshot]
+            position = screenshot_with_position[:position]
             set = app_screenshot_sets_map[device_type]
 
             unless set
@@ -320,7 +321,7 @@ module Deliver
 
             Deliver.retry_api_call do
               UI.message("Uploading '#{screenshot.path}'...")
-              set.upload_screenshot(path: screenshot.path, wait_for_processing: wait_for_processing)
+              set.upload_screenshot(path: screenshot.path, wait_for_processing: wait_for_processing, position: position)
             end
           end
         end

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -30,9 +30,7 @@ module Deliver
       updated_sets_per_language = get_updated_screenshots(localizations, screenshots_per_language)
       checksums_to_delete = get_checksums_to_delete(localizations, updated_sets_per_language)
 
-      if options[:overwrite_screenshots]
-        delete_screenshots(localizations, checksums_to_delete, max_n_threads)
-      end
+      delete_screenshots(localizations, checksums_to_delete, max_n_threads)
 
       # Finding languages to enable
       languages = screenshots_per_language.keys

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -144,7 +144,7 @@ module Deliver
           next unless app_store_screenshots.size > candidates_with_checksums.size
 
           index = candidates_with_checksums.size
-          while index < candidates_with_checksums.size
+          while index < app_store_screenshots.size
             # add a "nil" screenshot for every position that will no longer be filled (in order to delete them)
             changed_screenshots_per_device_type[device_type] << {
                 screenshot: nil,


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Currently, whenever any media upload is done, all of the screenshots and previews are deleted and then uploaded again. This is inefficient but, even more importantly, it increases the chance of an error happening since more operations are being performed. This PR tries to limit the deletions and uploads to only the media that has actually been changed.

### Description
In this PR, the checksums of the media that is received and is currently available on App Store Connect are compared. Whenever there is a mismatch, the media instance will be deleted (if the overwrite option is specified) and the new media will be put in the specified position.

### Testing Steps
Ran tests