### PR TITLE
[deliver] Fix the deletion of media during metadata upload

### DIFF
--- a/deliver/lib/deliver/upload_app_previews.rb
+++ b/deliver/lib/deliver/upload_app_previews.rb
@@ -61,9 +61,6 @@ module Deliver
       # Get localizations on version
       n_threads = [max_n_threads, localizations.length].min
       Parallel.each(localizations, in_threads: n_threads) do |localization|
-        # Only delete app previews if trying to upload
-        next unless previews_per_language.keys.include?(localization.locale)
-
         # Iterate over all app previews for each set and delete
         previews_sets = localization.get_app_preview_sets
 
@@ -88,7 +85,7 @@ module Deliver
           UI.user_error!("Failed verification of all previews deleted... #{count} preview(s) still exist")
         else
           UI.error("Failed to delete all previews... Tries remaining: #{tries}")
-          delete_app_previews(localizations, previews_per_language, tries: tries)
+          delete_app_previews(localizations, previews_per_language, max_n_threads, tries: tries)
         end
       else
         UI.message("Successfully deleted all previews")

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -63,6 +63,8 @@ module Deliver
       Parallel.each(localizations, in_threads: n_threads) do |localization|
         # Iterate over all screenshots for each set and delete
         screenshot_sets = localization.get_app_screenshot_sets
+
+        # Multi threading delete on single localization
         screenshot_sets.each do |screenshot_set|
           UI.message("Removing all previously uploaded screenshots for '#{localization.locale}' '#{screenshot_set.screenshot_display_type}'...")
           screenshot_set.app_screenshots.each do |screenshot|

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -61,13 +61,8 @@ module Deliver
       # Get localizations on version
       n_threads = [max_n_threads, localizations.length].min
       Parallel.each(localizations, in_threads: n_threads) do |localization|
-        # Only delete screenshots if trying to upload
-        next unless screenshots_per_language.keys.include?(localization.locale)
-
         # Iterate over all screenshots for each set and delete
         screenshot_sets = localization.get_app_screenshot_sets
-
-        # Multi threading delete on single localization
         screenshot_sets.each do |screenshot_set|
           UI.message("Removing all previously uploaded screenshots for '#{localization.locale}' '#{screenshot_set.screenshot_display_type}'...")
           screenshot_set.app_screenshots.each do |screenshot|
@@ -89,7 +84,7 @@ module Deliver
           UI.user_error!("Failed verification of all screenshots deleted... #{count} screenshot(s) still exist")
         else
           UI.error("Failed to delete all screenshots... Tries remaining: #{tries}")
-          delete_screenshots(localizations, screenshots_per_language, tries: tries)
+          delete_screenshots(localizations, screenshots_per_language, max_n_threads, tries: tries)
         end
       else
         UI.message("Successfully deleted all screenshots")
@@ -101,6 +96,7 @@ module Deliver
       localizations.each do |localization|
         screenshot_sets = localization.get_app_screenshot_sets
         screenshot_sets.each do |screenshot_set|
+          UI.message("In count, #{localization.locale}:#{screenshot_set.screenshot_display_type} = #{screenshot_set.app_screenshots}")
           count += screenshot_set.app_screenshots.size
         end
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
We encountered a metadata upload (with media) that was failing for the following reason: `comparison of Integer with Hash failed`. The issue was being reported when performing a comparison of `max_n_threads` and `localizations.length` in `delete_screenshots()`. 

### Description
The reason why the metadata upload was failing consists out of two parts:
1) Not all of the screenshots were being deleted as locales that are not being updated were being skipped. However, when the number of remaining screenshots was being calculated, _all screenshot sets_ were being taken into account. Because of this, the deletion would always retry as there would always be some remaining screenshots that were not deleted.
2) When `delete_screenshots()` would be called again for a retry, we were not passing the `max_n_threads` parameter, causing the `comparison of Integer with Hash failed` error.

Both of these issues are fixed in this PR for screenshots and previews.

### Testing Steps
Ran locally
