### PR TITLE
[deliver] Add delta upload for previews

### DIFF
--- a/deliver/lib/deliver/upload_app_previews.rb
+++ b/deliver/lib/deliver/upload_app_previews.rb
@@ -350,7 +350,8 @@ module Deliver
 
             Deliver.retry_api_call do
               UI.message("Uploading '#{changed_preview.path}'...")
-              uploaded_app_store_previews << app_store_preview_set.upload_preview(path: changed_preview.path, position: position)
+              # wait_for_processing is set to false and frame_time_code to nil since the waiting will be done later
+              uploaded_app_store_previews << app_store_preview_set.upload_preview(path: changed_preview.path, wait_for_processing: false, position: position)
             end
           end
 
@@ -361,7 +362,7 @@ module Deliver
           uploaded_app_store_previews.each do |uploaded_app_store_preview|
             Deliver.retry_api_call do
               UI.message("Waiting for #{uploaded_app_store_preview.id} for '#{language}', '#{preview_type}' to finish processing")
-              Spaceship::ConnectAPI::AppPreview.wait_for_processing(app_preview_id: uploaded_app_store_preview.id, frame_time_code: frame_time_code)
+              Spaceship::ConnectAPI::AppPreview.do_wait_for_processing(app_preview_id: uploaded_app_store_preview.id, frame_time_code: frame_time_code)
             end
           end
         end

--- a/deliver/lib/deliver/upload_app_previews.rb
+++ b/deliver/lib/deliver/upload_app_previews.rb
@@ -235,7 +235,7 @@ module Deliver
           # Skip if there are no specified previews to delete for the given locale and preview type
           next unless previews_to_delete_per_preview_type.key?(preview_type)
           previews_to_delete_for_preview_type = previews_to_delete_per_preview_type[preview_type][:previews]
-          UI.message("Removing #{previews_to_delete_for_preview_type.size} screenshots for '#{language}' '#{preview_type}'...")
+          UI.message("Removing #{previews_to_delete_for_preview_type.size} previews for '#{language}' '#{preview_type}'...")
 
           ids_to_delete = previews_to_delete_for_preview_type.map(&:id)
 
@@ -264,7 +264,7 @@ module Deliver
           UI.user_error!("Failed verification of all app previews deleted... #{count} app preview(s) still exist")
         else
           UI.error("Failed to delete all app previews... Tries remaining: #{tries}")
-          delete_screenshots(localizations, reloaded_app_store_sets_map, app_store_previews_to_delete, max_n_threads, tries: tries)
+          delete_app_previews(localizations, reloaded_app_store_sets_map, app_store_previews_to_delete, max_n_threads, tries: tries)
         end
       else
         UI.message("Successfully deleted all previews")
@@ -335,7 +335,7 @@ module Deliver
           changed_previews_to_be_uploaded.each do |changed_preview_with_position|
             changed_preview = changed_preview_with_position[:preview]
 
-            # don't upload the empty screenshots that represent the no-longer filled positions
+            # don't upload the empty previews that represent the no-longer filled positions
             next if changed_preview.nil?
 
             position = changed_preview_with_position[:position]

--- a/deliver/lib/deliver/upload_app_previews.rb
+++ b/deliver/lib/deliver/upload_app_previews.rb
@@ -23,16 +23,19 @@ module Deliver
       UI.important("Will begin uploading app previews for '#{version.version_string}' on App Store Connect")
 
       UI.message("Starting with the upload of app previews...")
-      previews_per_language = previews.group_by(&:language)
+      candidate_previews_per_language = previews.group_by(&:language)
 
       localizations = version.get_app_store_version_localizations
 
-      if options[:overwrite_app_previews]
-        delete_app_previews(localizations, previews_per_language, max_n_threads)
-      end
+      app_store_preview_sets_map = load_app_store_preview_sets(localizations)
+
+      changed_sets_per_language = get_changed_previews(app_store_preview_sets_map, candidate_previews_per_language)
+      app_store_previews_to_delete = get_app_store_previews_to_delete(app_store_preview_sets_map, changed_sets_per_language)
+
+      delete_app_previews(localizations, app_store_preview_sets_map, app_store_previews_to_delete, max_n_threads)
 
       # Finding languages to enable
-      languages = previews_per_language.keys
+      languages = candidate_previews_per_language.keys
       locales_to_enable = languages - localizations.map(&:locale)
 
       if locales_to_enable.count > 0
@@ -52,65 +55,241 @@ module Deliver
         localizations = version.get_app_store_version_localizations
       end
 
-      upload_app_previews(previews_per_language, localizations, options, max_n_threads)
+      upload_app_previews(changed_sets_per_language, localizations, options, max_n_threads)
     end
 
-    def delete_app_previews(localizations, previews_per_language, max_n_threads, tries: 5)
+    def load_app_store_preview_sets(localizations)
+      app_store_preview_sets_map = {}
+
+      localizations.each do |localization|
+        app_store_sets_for_language = {}
+        app_store_preview_sets = localization.get_app_preview_sets
+        app_store_preview_sets.each do |app_store_preview_set|
+          app_store_sets_for_language[app_store_preview_set.preview_type] = app_store_preview_set
+        end
+
+        app_store_preview_sets_map[localization.locale] = app_store_sets_for_language
+      end
+
+      app_store_preview_sets_map
+    end
+
+    def get_changed_previews(app_store_preview_sets_map, candidate_previews_per_language)
+      candidate_sets_per_language = {} # per locale and type; all provided previews
+      changed_sets_per_language = {} # per locale and type; previews that have been added, removed or updated
+
+      # first, divide the new previews into sets
+      candidate_previews_per_language.each do |language, candidates_for_language|
+        candidates_per_preview_type = {}
+
+        candidates_for_language.each do |candidate_preview|
+          preview_type = candidate_preview.device_type
+
+          if preview_type.nil?
+            UI.error("Error... Preview size #{candidate_preview.screen_size} not valid for App Store Connect")
+            next
+          end
+
+          bytes = File.binread(candidate_preview.path)
+          checksum = Digest::MD5.hexdigest(bytes)
+
+          candidates_per_preview_type[preview_type] ||= []
+          candidates_per_preview_type[preview_type] << {
+              preview: candidate_preview,
+              checksum: checksum
+          }
+        end
+
+        candidate_sets_per_language[language] = candidates_per_preview_type
+      end
+
+      # remove any duplicate by comparing checksums, keep the first occurrence only
+      candidate_sets_per_language.values.each do |candidate_sets_per_preview_type|
+        candidate_sets_per_preview_type.values.each do |candidates_with_checksums|
+          candidates_with_checksums.uniq! { |preview| preview[:checksum] }
+        end
+      end
+
+      # then, compare the new previews with the existing ones
+      candidate_sets_per_language.each do |language, candidate_sets_per_preview_type|
+        changed_previews_per_type = {}
+
+        unless app_store_preview_sets_map.key?(language)
+          UI.error("Couldn't find localization on version for #{language}")
+          next
+        end
+
+        app_store_sets_per_preview_type = app_store_preview_sets_map[language]
+        candidate_sets_per_preview_type.each do |preview_type, candidates_with_checksums|
+          app_store_previews = app_store_sets_per_preview_type[preview_type].app_previews
+          changed_previews_per_type[preview_type] ||= []
+
+          candidates_with_checksums.each_with_index do |candidate_with_checksum, index|
+            if index >= 3
+              UI.error("Too many previews found for device '#{preview_type}' in '#{language}', skipping this one (#{candidate_with_checksum[:preview].path})")
+              next
+            end
+
+            app_store_preview = app_store_previews[index]
+            next unless app_store_preview.nil? || app_store_preview.source_file_checksum != candidate_with_checksum[:checksum]
+
+            # the added and updated previews from the candidates
+            changed_previews_per_type[preview_type] << {
+                preview: candidate_with_checksum[:preview],
+                position: index
+            }
+          end
+
+          # if there are more (existing) app store previews, it means some need to be removed without being replaced
+          next unless app_store_previews.size > candidates_with_checksums.size
+
+          index = candidates_with_checksums.size
+          while index < app_store_previews.size
+            # add a "nil" preview for every position that will no longer be filled (in order to delete them)
+            changed_previews_per_type[preview_type] << {
+                preview: nil,
+                position: index
+            }
+            index += 1
+          end
+        end
+
+        changed_sets_per_language[language] = changed_previews_per_type
+
+        count = changed_previews_per_type.values.reduce(0) { |sum, previews_with_positions| sum + previews_with_positions.size }
+        UI.message("Found #{count} added, removed or updated previews for language #{language}")
+      end
+
+      changed_sets_per_language
+    end
+
+    def get_app_store_previews_to_delete(app_store_preview_sets_map, changed_sets_per_language)
+      previews_to_delete = {} # per language and preview type
+
+      changed_sets_per_language.each do |language, changed_sets_per_preview_type|
+        previews_to_delete_per_preview_type = {}
+        app_store_sets_per_preview_type = app_store_preview_sets_map[language]
+
+        app_store_sets_per_preview_type.values.each do |app_store_preview_set|
+          preview_type = app_store_preview_set.preview_type
+
+          unless changed_sets_per_preview_type.key?(preview_type)
+            # if there is no preview type specified, add empty array of previews to delete
+            previews_to_delete_per_preview_type[preview_type] = {
+                previews: [],
+                count_after_delete: app_store_preview_set.app_previews.size
+            }
+            next
+          end
+
+          changed_preview_set = changed_sets_per_preview_type[preview_type]
+          changed_preview_positions = changed_preview_set.map { |preview_with_position| preview_with_position[:position] }
+          previews_to_delete_for_preview_type = []
+
+          app_store_preview_set.app_previews.each_with_index do |preview, index|
+            next unless changed_preview_positions.include?(index)
+            previews_to_delete_for_preview_type << preview
+          end
+
+          previews_to_delete_per_preview_type[preview_type] = {
+              previews: previews_to_delete_for_preview_type,
+              count_after_delete: app_store_preview_set.app_previews.size - previews_to_delete_for_preview_type.size
+          }
+        end
+
+        previews_to_delete[language] = previews_to_delete_per_preview_type
+      end
+
+      previews_to_delete
+    end
+
+    def get_expected_count_after_delete(app_store_previews_to_delete)
+      sum = 0
+
+      app_store_previews_to_delete.values.each do |previews_per_preview_type|
+        previews_per_preview_type.values.each do |preview_with_count|
+          sum += preview_with_count[:count_after_delete]
+        end
+      end
+
+      sum
+    end
+
+    def delete_app_previews(localizations, app_store_preview_sets_map, app_store_previews_to_delete, max_n_threads, tries: 5)
       tries -= 1
 
-      # Get localizations on version
+      # Multi threading delete on single localization
       n_threads = [max_n_threads, localizations.length].min
       Parallel.each(localizations, in_threads: n_threads) do |localization|
-        # Only delete app previews if trying to upload
-        next unless previews_per_language.keys.include?(localization.locale)
+        language = localization.locale
 
-        # Iterate over all app previews for each set and delete
-        previews_sets = localization.get_app_preview_sets
+        next unless app_store_previews_to_delete.key?(language)
 
-        # Multi threading delete on single localization
-        previews_sets.each do |preview_set|
-          UI.message("Removing all previously uploaded app previews for '#{localization.locale}' '#{preview_set.preview_type}'...")
-          preview_set.app_previews.each do |preview|
+        # Find all the previews that need to be deleted (via their ID) and delete them
+        app_store_sets_per_preview_type = app_store_preview_sets_map[language]
+
+        app_store_sets_per_preview_type.values.each do |app_store_preview_set|
+          preview_type = app_store_preview_set.preview_type
+          previews_to_delete_per_preview_type = app_store_previews_to_delete[language]
+
+          # Skip if there are no specified previews to delete for the given locale and preview type
+          next unless previews_to_delete_per_preview_type.key?(preview_type)
+          previews_to_delete_for_preview_type = previews_to_delete_per_preview_type[preview_type][:previews]
+          UI.message("Removing #{previews_to_delete_for_preview_type.size} screenshots for '#{language}' '#{preview_type}'...")
+
+          ids_to_delete = previews_to_delete_for_preview_type.map(&:id)
+
+          app_store_preview_set.app_previews.each do |app_store_preview|
+            next unless ids_to_delete.include?(app_store_preview.id)
+
+            UI.message("Deleting app preview - #{language} #{app_store_preview_set.preview_type} #{app_store_preview.id}")
             Deliver.retry_api_call do
-              UI.verbose("Deleting app preview - #{localization.locale} #{preview_set.preview_type} #{preview.id}")
-              preview.delete!
+              app_store_preview.delete!
+              UI.message("Deleted app preview - #{language} #{app_store_preview_set.preview_type} #{app_store_preview.id}")
             end
           end
         end
       end
 
-      # Verify all previews have been deleted
-      # Sometimes API requests will fail but the previews will still be deleted
-      count = count_previews(localizations)
+      # Verify all specified previews have been deleted
+      # Sometimes API requests will fail but previews will still be deleted
+      # Also, need to reload the sets to get the actual previews in App Store after the deletion
+      reloaded_app_store_sets_map = load_app_store_preview_sets(localizations)
+      actual_count = count_previews(reloaded_app_store_sets_map, app_store_previews_to_delete)
+      expected_count = get_expected_count_after_delete(app_store_previews_to_delete)
+      count = actual_count - expected_count
       UI.important("Number of previews not deleted: #{count}")
       if count > 0
         if tries.zero?
-          UI.user_error!("Failed verification of all previews deleted... #{count} preview(s) still exist")
+          UI.user_error!("Failed verification of all app previews deleted... #{count} app preview(s) still exist")
         else
-          UI.error("Failed to delete all previews... Tries remaining: #{tries}")
-          delete_app_previews(localizations, previews_per_language, tries: tries)
+          UI.error("Failed to delete all app previews... Tries remaining: #{tries}")
+          delete_screenshots(localizations, reloaded_app_store_sets_map, app_store_previews_to_delete, max_n_threads, tries: tries)
         end
       else
         UI.message("Successfully deleted all previews")
       end
     end
 
-    def count_previews(localizations)
+    def count_previews(app_store_preview_sets_map, app_store_previews_to_delete)
       count = 0
-      localizations.each do |localization|
-        preview_sets = localization.get_app_preview_sets
-        preview_sets.each do |preview_set|
-          count += preview_set.app_previews.size
+
+      app_store_preview_sets_map.each do |language, app_store_sets_for_language|
+        # disregard count for language if nothing is deleted in it
+        next unless app_store_previews_to_delete.key?(language)
+
+        app_store_sets_for_language.values.each do |app_store_set_for_preview_type|
+          count += app_store_set_for_preview_type.app_previews.size
         end
       end
 
       count
     end
 
-    def upload_app_previews(previews_per_language, localizations, options, max_n_threads)
+    def upload_app_previews(changed_sets_per_language, localizations, options, max_n_threads)
       # Check if should wait for processing
       # Default to waiting if submitting for review (since needed for submission)
-      # Otherwise use enviroment variable
+      # Otherwise use environment variable
       if ENV["DELIVER_SKIP_WAIT_FOR_PREVIEW_PROCESSING"].nil?
         wait_for_processing = options[:submit_for_review]
         UI.verbose("Setting wait_for_processing from ':submit_for_review' option")
@@ -129,11 +308,11 @@ module Deliver
 
       frame_time_code = options[:frame_time_code]
 
-      # Upload app previews
-      indized = {} # per language and device type
+      # need to reload the sets after the delete operations
+      app_store_preview_sets_map = load_app_store_preview_sets(localizations)
 
-      n_threads = [max_n_threads, previews_per_language.length].min
-      Parallel.each(previews_per_language, in_threads: n_threads) do |language, previews_for_language|
+      n_threads = [max_n_threads, changed_sets_per_language.keys.length].min
+      Parallel.each(changed_sets_per_language, in_threads: n_threads) do |language, changed_sets_per_preview_type|
         # Find localization to upload app previews to
         localization = localizations.find do |l|
           l.locale == language
@@ -144,64 +323,31 @@ module Deliver
           next
         end
 
-        indized[localization.locale] ||= {}
+        app_store_sets_for_language = app_store_preview_sets_map[language]
 
-        # Create map to find app preview set to add app preview to
-        app_preview_sets_map = {}
-        app_preview_sets = localization.get_app_preview_sets
-        app_preview_sets.each do |app_preview_set|
-          app_preview_sets_map[app_preview_set.preview_type] = app_preview_set
+        changed_sets_per_preview_type.each do |preview_type, changed_previews_for_preview_type|
+          changed_previews_to_be_uploaded = changed_previews_for_preview_type.reject { |preview_with_position| preview_with_position[:preview].nil? }
+          UI.message("Uploading #{changed_previews_to_be_uploaded.length} app previews for '#{language}', '#{preview_type}'")
 
-          # Set initial app previews count
-          indized[localization.locale][app_preview_set.preview_type] ||= {
-              count: app_preview_set.app_previews.size,
-              checksums: []
-          }
+          changed_previews_to_be_uploaded.each do |changed_preview_with_position|
+            changed_preview = changed_preview_with_position[:preview]
 
-          checksums = app_preview_set.app_previews.map(&:source_file_checksum).uniq
-          indized[localization.locale][app_preview_set.preview_type][:checksums] = checksums
-        end
+            # don't upload the empty screenshots that represent the no-longer filled positions
+            next if changed_preview.nil?
 
-        UI.message("Uploading #{previews_for_language.length} app previews for language #{language}")
-        previews_for_language.each do |preview|
-          Deliver.retry_api_call do
-            display_type = preview.device_type
-            set = app_preview_sets_map[display_type]
+            position = changed_preview_with_position[:position]
+            app_store_preview_set = app_store_sets_for_language[preview_type]
 
-            if display_type.nil?
-              UI.error("Error... App preview size #{preview.screen_size} not valid for App Store Connect")
-              next
-            end
-
-            unless set
-              set = localization.create_app_preview_set(attributes: {
-                  previewType: display_type
+            unless app_store_preview_set
+              app_store_preview_set = localization.create_app_preview_set(attributes: {
+                  previewType: preview_type
               })
-              app_preview_sets_map[display_type] = set
-
-              indized[localization.locale][set.preview_type] = {
-                  count: 0,
-                  checksums: []
-              }
+              app_store_sets_for_language[preview_type] = app_store_preview_set
             end
 
-            index = indized[localization.locale][set.preview_type][:count]
-
-            if index >= 3
-              UI.error("Too many app previews found for device '#{preview.formatted_name}' in '#{preview.language}', skipping this one (#{preview.path})")
-              next
-            end
-
-            bytes = File.binread(preview.path)
-            checksum = Digest::MD5.hexdigest(bytes)
-            duplicate = indized[localization.locale][set.preview_type][:checksums].include?(checksum)
-
-            if duplicate
-              UI.message("Previous uploaded. Skipping '#{preview.path}'...")
-            else
-              indized[localization.locale][set.preview_type][:count] += 1
-              UI.message("Uploading '#{preview.path}'...")
-              set.upload_preview(path: preview.path, wait_for_processing: wait_for_processing, frame_time_code: frame_time_code)
+            Deliver.retry_api_call do
+              UI.message("Uploading '#{changed_preview.path}'...")
+              app_store_preview_set.upload_preview(path: changed_preview.path, wait_for_processing: wait_for_processing, position: position, frame_time_code: frame_time_code)
             end
           end
         end

--- a/deliver/lib/deliver/upload_app_previews.rb
+++ b/deliver/lib/deliver/upload_app_previews.rb
@@ -361,6 +361,9 @@ module Deliver
         uploaded_app_store_previews_per_preview_type.each do |preview_type, uploaded_app_store_previews|
           uploaded_app_store_previews.each do |uploaded_app_store_preview|
             Deliver.retry_api_call do
+              # add a random waiting time between calls in order not to overwhelm the Apple API
+              sleep(Random.rand(0..3))
+
               UI.message("Waiting for #{uploaded_app_store_preview.id} for '#{language}', '#{preview_type}' to finish processing")
               Spaceship::ConnectAPI::AppPreview.do_wait_for_processing(app_preview_id: uploaded_app_store_preview.id, frame_time_code: frame_time_code)
             end

--- a/spaceship/lib/spaceship/connect_api/models/app_preview.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_preview.rb
@@ -64,7 +64,7 @@ module Spaceship
       # @param app_preview_set_id The AppPreviewSet id
       # @param path The path of the file
       # @param frame_time_code The time code for the preview still frame (ex: "00:00:07:01")
-      def self.create(app_preview_set_id: nil, path: nil, wait_for_processing: true, frame_time_code: nil)
+      def self.create(app_preview_set_id: nil, path: nil)
         require 'faraday'
 
         filename = File.basename(path)
@@ -137,29 +137,27 @@ module Spaceship
           raise error unless preview.complete?
         end
 
-        # Poll for video processing completion to set still frame time
-        wait_for_processing = true unless frame_time_code.nil?
-        if wait_for_processing
-          loop do
-            unless preview.video_url.nil?
-              puts("Preview processing complete!") if Spaceship::Globals.verbose?
-              break if frame_time_code.nil?
-              preview = preview.update(attributes: {
-                previewFrameTimeCode: frame_time_code
-              })
-              puts("Updated preview frame time code!") if Spaceship::Globals.verbose?
-              break
-            end
-
-            sleep_time = 30
-            puts("Waiting #{sleep_time} seconds before checking status of processing...") if Spaceship::Globals.verbose?
-            sleep(sleep_time)
-
-            preview = Spaceship::ConnectAPI::AppPreview.get(app_preview_id: preview.id)
-          end
-        end
-
         preview
+      end
+
+      def self.wait_for_processing(app_preview_id: nil, frame_time_code: nil)
+        loop do
+          preview = Spaceship::ConnectAPI::AppPreview.get(app_preview_id: app_preview_id)
+
+          unless preview.video_url.nil?
+            puts("Preview processing complete!") if Spaceship::Globals.verbose?
+            break if frame_time_code.nil?
+            preview.update(attributes: {
+                previewFrameTimeCode: frame_time_code
+            })
+            puts("Updated preview frame time code!") if Spaceship::Globals.verbose?
+            break
+          end
+
+          sleep_time = 30
+          puts("Waiting #{sleep_time} seconds before checking status of processing...") if Spaceship::Globals.verbose?
+          sleep(sleep_time)
+        end
       end
 
       def update(attributes: nil)

--- a/spaceship/lib/spaceship/connect_api/models/app_preview.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_preview.rb
@@ -64,7 +64,7 @@ module Spaceship
       # @param app_preview_set_id The AppPreviewSet id
       # @param path The path of the file
       # @param frame_time_code The time code for the preview still frame (ex: "00:00:07:01")
-      def self.create(app_preview_set_id: nil, path: nil)
+      def self.create(app_preview_set_id: nil, path: nil, wait_for_processing: true, frame_time_code: nil)
         require 'faraday'
 
         filename = File.basename(path)
@@ -137,10 +137,16 @@ module Spaceship
           raise error unless preview.complete?
         end
 
+        # Poll for video processing completion to set still frame time
+        wait_for_processing = true unless frame_time_code.nil?
+        if wait_for_processing
+          do_wait_for_processing(app_preview_id: preview.id, frame_time_code: frame_time_code)
+        end
+
         preview
       end
 
-      def self.wait_for_processing(app_preview_id: nil, frame_time_code: nil)
+      def self.do_wait_for_processing(app_preview_id: nil, frame_time_code: nil)
         loop do
           preview = Spaceship::ConnectAPI::AppPreview.get(app_preview_id: app_preview_id)
 

--- a/spaceship/lib/spaceship/connect_api/models/app_preview_set.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_preview_set.rb
@@ -62,9 +62,9 @@ module Spaceship
         return Spaceship::ConnectAPI.get_app_preview_set(app_preview_set_id: app_preview_set_id, filter: nil, includes: includes, limit: nil, sort: nil).first
       end
 
-      def upload_preview(path: nil, wait_for_processing: true, position: nil, frame_time_code: nil)
+      def upload_preview(path: nil, position: nil)
         # Upload preview
-        preview = Spaceship::ConnectAPI::AppPreview.create(app_preview_set_id: id, path: path, wait_for_processing: wait_for_processing, frame_time_code: frame_time_code)
+        preview = Spaceship::ConnectAPI::AppPreview.create(app_preview_set_id: id, path: path)
 
         # Reposition (if specified)
         unless position.nil?

--- a/spaceship/lib/spaceship/connect_api/models/app_preview_set.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_preview_set.rb
@@ -62,9 +62,9 @@ module Spaceship
         return Spaceship::ConnectAPI.get_app_preview_set(app_preview_set_id: app_preview_set_id, filter: nil, includes: includes, limit: nil, sort: nil).first
       end
 
-      def upload_preview(path: nil, position: nil)
+      def upload_preview(path: nil, wait_for_processing: true, position: nil, frame_time_code: nil)
         # Upload preview
-        preview = Spaceship::ConnectAPI::AppPreview.create(app_preview_set_id: id, path: path)
+        preview = Spaceship::ConnectAPI::AppPreview.create(app_preview_set_id: id, path: path, wait_for_processing: wait_for_processing, frame_time_code: frame_time_code)
 
         # Reposition (if specified)
         unless position.nil?


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Similarly to the screenshot upload, we want to limit the number of calls being made to Apple during an update of the previews. This should mean that there is less chance of a failure (due to the recent deprecation of old Apple APIs) and should also hopefully speed up the process of preview upload (which has been known to take a long time to complete recently).

### Description
This PR implements the same logic used currently with screenshots (see https://github.com/BendingSpoons/fastlane/pull/26). We compare the received, "candidate" previews to the already existing ones on App Store Connect and only delete and/or upload the necessary ones, instead of deleting everything and uploading everything.

### Testing Steps
Ran it locally.
Use cases tested:
- [x] No changes in previews -> No actions taken
- [x] Duplicate present in candidates -> It is not uploaded
- [x] Previews present in bundle but not on App Store Connect (manually removed from there) -> Missing previews are uploaded
- [x] Preview not present in bundle but is on App Store Connect (it would require a new testing `metadata` PR with a removed video, or is there an easier way?)
- [x] Reordering of preview (Readit has only one preview per language and device type and duplicates are discarded, can we use some other video?)
