### PR TITLE
[spaceship] Add support for app analytics opt in rate

### DIFF
--- a/spaceship/lib/spaceship/tunes/app_analytics.rb
+++ b/spaceship/lib/spaceship/tunes/app_analytics.rb
@@ -12,6 +12,11 @@ module Spaceship
         end
       end
 
+      # App info (including opt-in rate)
+      def app_analytics_info
+        client.app_analytics_info(app_id: self.apple_id)
+      end
+
       # App Store / Impressions Unique Devices
       def app_impressions
         start_t, end_t = time_last_7_days

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -575,6 +575,18 @@ module Spaceship
     # @!group AppAnalytics
     #####################################################
 
+    def app_analytics_info(app_id: nil)
+      resource = app_id.nil? ? 'all' : app_id
+
+      r = request(:get) do |req|
+        req.url("https://analytics.itunes.apple.com/analytics/api/v1/app-info/#{resource}")
+        req.headers['Content-Type'] = 'application/json'
+        req.headers['X-Requested-By'] = 'analytics.itunes.apple.com'
+      end
+
+      parse_response(r)
+    end
+
     def time_series_analytics(app_ids, measures, start_time, end_time, frequency, view_by, filters = nil)
       data = {
         adamId: app_ids,


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR adds new methods to retrieve the opt in rate of an app.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
There's a new method to retrieve the app analytics "app infos", including an app's metrics opt in rate. This is exposed both in the `Tunes` client and as a convenience method in the `AppAnalytics` class.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
Tested live.