### PR TITLE
[Fix] Replace nil with empty array in newly created sets

### DIFF
--- a/deliver/lib/deliver/upload_app_previews.rb
+++ b/deliver/lib/deliver/upload_app_previews.rb
@@ -137,12 +137,12 @@ module Deliver
             app_store_preview_set = localization.create_app_preview_set(attributes: {
                 previewType: preview_type
             })
+            # the app_previews field of a newly created set tends to be nil, when it should be []
+            app_store_preview_set.app_previews ||= []
             app_store_sets_per_preview_type[preview_type] = app_store_preview_set
           end
 
-          app_store_previews = app_store_sets_per_preview_type[preview_type].app_previews
-          # in case the set has just been created on App Store, it's app_previews can be nil
-          app_store_previews ||= []
+          app_store_previews = app_store_preview_set.app_previews
 
           changed_previews_per_type[preview_type] ||= []
 

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -137,12 +137,12 @@ module Deliver
             app_store_screenshot_set = localization.create_app_screenshot_set(attributes: {
                 screenshotDisplayType: device_type
             })
+            # the app_screenshot field of a newly created set tends to be nil, when it should be []
+            app_store_screenshot_set.app_screenshots ||= []
             app_store_sets_per_device_type[device_type] = app_store_screenshot_set
           end
 
-          app_store_screenshots = app_store_sets_per_device_type[device_type].app_screenshots
-          # in case the set has just been created on App Store, it's app_screenshots can be nil
-          app_store_screenshots ||= []
+          app_store_screenshots = app_store_screenshot_set.app_screenshots
 
           changed_screenshots_per_device_type[device_type] ||= []
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
The result of a set creation leaves a `nil` value for `app_screenshots` and `app_previews` (depending on whether the set is for screenshots or previews). This in turn causes issues when trying to iterate over those fields. The issue was already known but the fix we put in place was not good enough to deal with the problem completely.

### Description
This PR introduces a fix where we replace the `nil` value with an empty array _before_ we put the newly created set in the hash containing all the sets that is reused later on.

### Testing Steps
