### PR TITLE
[spaceship] Fix IAP upload

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/in_app_purchase.rb
+++ b/spaceship/lib/spaceship/connect_api/models/in_app_purchase.rb
@@ -44,6 +44,10 @@ module Spaceship
         resps = Spaceship::ConnectAPI.get_in_app_purchases(filter: filter, includes: includes).all_pages
         return resps.flat_map(&:to_models)
       end
+
+      def self.get(in_app_purchase_id: nil)
+        return Spaceship::ConnectAPI.get_in_app_purchase(in_app_purchase_id: in_app_purchase_id, filter: nil, includes: nil, limit: nil, sort: nil).first
+      end
     end
   end
 end

--- a/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
@@ -936,6 +936,11 @@ module Spaceship
         # inAppPurchases
         #
 
+        def get_in_app_purchase(in_app_purchase_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
+          params = tunes_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
+          tunes_request_client.get("inAppPurchases/#{in_app_purchase_id}", params)
+        end
+
         def get_in_app_purchases(app_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
           params = tunes_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
           tunes_request_client.get("apps/#{app_id}/inAppPurchases", params)

--- a/spaceship/lib/spaceship/tunes/iap_detail.rb
+++ b/spaceship/lib/spaceship/tunes/iap_detail.rb
@@ -133,6 +133,8 @@ module Spaceship
             status = proposed_versions[language][:status]
           elsif is_rejected
             status = rejected_versions[language][:status]
+          elsif is_active
+            status = active_versions[language][:status]
           end
 
           # Note that id=nil is valid only if the product doesn't exist; setting a nil value on an existing product
@@ -142,6 +144,8 @@ module Spaceship
             id = proposed_versions[language][:id]
           elsif is_rejected
             id = rejected_versions[language][:id]
+          elsif is_active
+            id = active_versions[language][:id]
           end
 
           new_versions << {


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR fixes a critical bug that prevented the upload of changes to already existing and approved IAPs.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
This PR adds back the handling of _active_ IAPs. 

In order for the update of an IAP to go through, the IAP status in the submission must coincide with the one received from App Store Connect. In case the IAP is new, the status must be _proposed_
In the existing codebase, the IAP status of the submission remains _proposed_ also for IAPs that are already active (i.e., approved) on App Store Connect, causing Apple servers to crash with `ITC.response.error.OPERATION_FAILED`.

In addition, we incorporate a new convenience method for the App Store Connect API to retrieve some IAP data.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
Live testing.