### PR TITLE
[spaceship] Add API to retrieve App Store Connect provider news

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -680,6 +680,22 @@ module Spaceship
       return all_messages
     end
 
+    # Get provider news from App Store Connect's "olympus" endpoint
+    def fetch_provider_news_messages
+      all_messages = []
+
+      messages_request = request(:get, "https://appstoreconnect.apple.com/olympus/v1/providerNews")
+      body = messages_request.body
+      if body
+        body = JSON.parse(body) if body.kind_of?(String)
+        body.map do |messages|
+          all_messages.push(messages["message"])
+        end
+      end
+
+      return all_messages
+    end
+
     #####################################################
     # @!group Helpers
     #####################################################

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -684,8 +684,8 @@ module Spaceship
     def fetch_provider_news_messages
       all_messages = []
 
-      messages_request = request(:get, "https://appstoreconnect.apple.com/olympus/v1/providerNews")
-      body = messages_request.body
+      messages_response = request(:get, "https://appstoreconnect.apple.com/olympus/v1/providerNews")
+      body = messages_response.body
       if body
         body = JSON.parse(body) if body.kind_of?(String)
         body.map do |messages|

--- a/spaceship/spec/portal/fixtures/provider_news_messages.json
+++ b/spaceship/spec/portal/fixtures/provider_news_messages.json
@@ -1,0 +1,7 @@
+[ {
+    "id" : "provider_news",
+    "group" : "General",
+    "subject" : "Upcoming Authentication Requirement for App Store Connect",
+    "message" : "Starting February 2021, additional authentication will be required for all users to sign in to App Store Connect. You can enable two-step verification or two-factor authentication now for the Apple ID associated with your developer account. Visit the Security section of your <a href=\"https://appleid.apple.com/\" target=\"_blank\">Apple ID account</a> or the Apple ID section of <a href=\"https://support.apple.com/HT204915\" target=\"_blank\">Settings on your iPhone, iPad, or iPod touch</a>.",
+    "priority" : null
+  } ]

--- a/spaceship/spec/portal/portal_client_spec.rb
+++ b/spaceship/spec/portal/portal_client_spec.rb
@@ -340,6 +340,29 @@ the developer website<a/>.<br />"
         expect(response.first).to eq(expected_first_message)
       end
     end
+
+    describe '#fetch_provider_news_messages' do
+      it 'makes a request to fetch all Provider News warnings from Olympus' do
+        # Stub the GET request that the method will make
+        PortalStubbing.adp_stub_fetch_provider_news_messages
+
+        response = subject.fetch_provider_news_messages
+
+        # The method should make a GET request to this URL:
+        expect(a_request(:get, 'https://appstoreconnect.apple.com/olympus/v1/providerNews')).to have_been_made
+
+        # The method should just return the "message" key's value(s) in an array.
+
+        expected_first_message = "Starting February 2021, additional authentication \
+will be required for all users to sign in to App Store Connect. You can enable \
+two-step verification or two-factor authentication now for the Apple ID associated \
+with your developer account. Visit the Security section of your <a href=\"https://appleid.apple.com/\" \
+target=\"_blank\">Apple ID account</a> or the Apple ID section of <a href=\"https://support.apple.com/HT204915\" \
+target=\"_blank\">Settings on your iPhone, iPad, or iPod touch</a>."
+
+        expect(response.first).to eq(expected_first_message)
+      end
+    end
   end
 
   describe 'keys api' do

--- a/spaceship/spec/portal/portal_stubbing.rb
+++ b/spaceship/spec/portal/portal_stubbing.rb
@@ -343,5 +343,10 @@ class PortalStubbing
       stub_request(:get, 'https://appstoreconnect.apple.com/olympus/v1/contractMessages').
         to_return(status: 200, body: adp_read_fixture_file('program_license_agreement_messages.json'), headers: { 'Content-Type' => 'application/json' })
     end
+
+    def adp_stub_fetch_provider_news_messages
+      stub_request(:get, 'https://appstoreconnect.apple.com/olympus/v1/providerNews').
+        to_return(status: 200, body: adp_read_fixture_file('provider_news_messages.json'), headers: { 'Content-Type' => 'application/json' })
+    end
   end
 end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
In order to notify developers about App Store Connect provider news and contract messages, the API for retrieving provider news needed to be added.

### Description
This PR adds an API for retrieving App Store Connect provider news to the `Spaceship::Client`. 

### Testing Steps
Tested with a local bunker.
