### PR TITLE
[spaceship] Introduce auto-login with 2FA

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -434,6 +434,12 @@ module Spaceship
           # In this case we don't actually care about the exact exception, and why it was failing
           # because either way, we'll have to do a fresh login, where we do the actual error handling
           puts("Available session is not valid any more. Continuing with normal login.")
+
+          # BSP: this should not be necessary, because the login() operation below should always provide the subsequent
+          # call to fetch_olympus_session() with a valid cookie. However, we noticed some unhandled 401 being raised by
+          # that call occasionaly that we haven't been able to fully debug. Cleaning the cookie before making the call
+          # seems to help, so here we do just that.
+          @cookie.cleanup(session: true)
         end
       end
       #

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -308,6 +308,24 @@ module Spaceship
       return path
     end
 
+    # Returns preferred path for storing global
+    # authentication mutex for two step verification.
+    def persistent_auth_mutex_path
+      if ENV["SPACESHIP_AUTH_MUTEX_PATH"]
+        path = File.expand_path(File.join(ENV["SPACESHIP_AUTH_MUTEX_PATH"], "spaceship", self.user, "auth_mutex"))
+      else
+        [File.join(self.fastlane_user_dir, "spaceship"), "~/.spaceship", "/var/tmp/spaceship", "#{Dir.tmpdir}/spaceship"].each do |dir|
+          dir_parts = File.split(dir)
+          if directory_accessible?(File.expand_path(dir_parts.first))
+            path = File.expand_path(File.join(dir, self.user, "auth_mutex"))
+            break
+          end
+        end
+      end
+
+      path
+    end
+
     #####################################################
     # @!group Automatic Paging
     #####################################################
@@ -403,11 +421,30 @@ module Spaceship
       end
     end
 
+    # Wrapper for send_shared_login_request_helper() that handles concurrent login attempts via a global authentication
+    # mutex. The mutex relies on filesystem locking to work across several processes.
+    def send_shared_login_request(user, password)
+      authenticated = false
+
+      File.open(persistent_auth_mutex_path, File::CREAT) {|f|
+        puts("Attempting to obtain lock on authentication mutex.")
+
+        # When used with File::LOCK_EX, flock() will wait until the lock is released
+        f.flock(File::LOCK_EX)
+
+        puts("Obtained lock on authentication mutex, proceeding with login procedure.")
+        authenticated = send_shared_login_request_helper(user, password)
+      }
+
+      puts("Authentication lock released.")
+      authenticated
+    end
+
     # This method is used for both the Apple Dev Portal and App Store Connect
     # This will also handle 2 step verification and 2 factor authentication
     #
     # It is called in `send_login_request` of sub classes (which the method `login`, above, transferred over to via `do_login`)
-    def send_shared_login_request(user, password)
+    def send_shared_login_request_helper(user, password)
       # Check if we have a cached/valid session
       #
       # Background:

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -870,14 +870,6 @@ module Spaceship
           msg = "Auth lost"
           logger.warn(msg)
           logger.warn(caller)
-          # BSP: force cookie invalidation. *DO NOT* re-initialize @cookie, or Faraday gets out of sync!
-          begin
-            FileUtils.remove_file(persistent_cookie_path)
-            logger.warn("Invalidated cookie at path: #{persistent_cookie_path}")
-          rescue StandardError => file_error
-            logger.warn("Exception while invalidating cookie at path: #{persistent_cookie_path}")
-            logger.warn(file_error)
-          end
           raise UnauthorizedAccessError.new, "Unauthorized Access"
         end
 

--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -134,18 +134,20 @@ module Spaceship
 
         phone_number = env_2fa_sms_default_phone_number
         phone_id = phone_id_from_number(response.body["trustedPhoneNumbers"], phone_number)
+        push_mode = push_mode_from_masked_number(response.body["trustedPhoneNumbers"], phone_number)
         # don't request sms if no trusted devices and env default is the only trusted number,
         # code was automatically sent
         should_request_code = !sms_automatically_sent(response)
         code_type = 'phone'
-        body = request_two_factor_code_from_phone(phone_id, phone_number, code_length, should_request_code)
+        body = request_two_factor_code_from_phone(phone_id, phone_number, code_length, push_mode, should_request_code)
       elsif sms_automatically_sent(response) # sms fallback, code was automatically sent
         fallback_number = response.body["trustedPhoneNumbers"].first
         phone_number = fallback_number["numberWithDialCode"]
         phone_id = fallback_number["id"]
+        push_mode = fallback_number['pushMode']
 
         code_type = 'phone'
-        body = request_two_factor_code_from_phone(phone_id, phone_number, code_length, false)
+        body = request_two_factor_code_from_phone(phone_id, phone_number, code_length, push_mode, false)
       elsif sms_fallback(response) # sms fallback but code wasn't sent bec > 1 phone number
         code_type = 'phone'
         body = request_two_factor_code_from_phone_choose(response.body["trustedPhoneNumbers"], code_length)
@@ -275,6 +277,15 @@ If it is, please open an issue at https://github.com/fastlane/fastlane/issues/ne
       end
     end
 
+    def push_mode_from_masked_number(phone_numbers, masked_number)
+      phone_numbers.each do |phone|
+        return phone['pushMode'] if phone['numberWithDialCode'] == masked_number
+      end
+
+      # If no pushMode was supplied, assume sms
+      return "sms"
+    end
+
     def request_two_factor_code_from_phone_choose(phone_numbers, code_length)
       puts("Please select a trusted phone number to send code to:")
 
@@ -283,18 +294,19 @@ If it is, please open an issue at https://github.com/fastlane/fastlane/issues/ne
       end
       chosen = choose_phone_number(available)
       phone_id = phone_id_from_masked_number(phone_numbers, chosen)
+      push_mode = push_mode_from_masked_number(phone_numbers, chosen)
 
-      request_two_factor_code_from_phone(phone_id, chosen, code_length)
+      request_two_factor_code_from_phone(phone_id, chosen, code_length, push_mode)
     end
 
     # this is used in two places: after choosing a phone number and when a phone number is set via ENV var
-    def request_two_factor_code_from_phone(phone_id, phone_number, code_length, should_request_code = true)
+    def request_two_factor_code_from_phone(phone_id, phone_number, code_length, push_mode = "sms", should_request_code = true)
       if should_request_code
         # Request code
         r = request(:put) do |req|
           req.url("https://idmsa.apple.com/appleauth/auth/verify/phone")
           req.headers['Content-Type'] = 'application/json'
-          req.body = { "phoneNumber" => { "id" => phone_id }, "mode" => "sms" }.to_json
+          req.body = { "phoneNumber" => { "id" => phone_id }, "mode" => push_mode }.to_json
           update_request_headers(req)
         end
 
@@ -307,7 +319,7 @@ If it is, please open an issue at https://github.com/fastlane/fastlane/issues/ne
 
       code = ask_for_2fa_code("Please enter the #{code_length} digit code you received at #{phone_number}:")
 
-      return { "securityCode" => { "code" => code.to_s }, "phoneNumber" => { "id" => phone_id }, "mode" => "sms" }.to_json
+      return { "securityCode" => { "code" => code.to_s }, "phoneNumber" => { "id" => phone_id }, "mode" => push_mode }.to_json
     end
 
     def store_session

--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -200,9 +200,15 @@ module Spaceship
           puts("Error: Incorrect verification code")
           depth += 1
           return handle_two_factor(response, depth)
-        end
+        else
+          # We shouldn't crash immediately, let's try a few times
+          puts("Error: Unexpected issue while authenticating with 2FA")
+          puts(ex.to_s)
+          depth += 1
+          return handle_two_factor(response, depth) if depth < 10 # Let's not try forever
 
-        raise ex
+          raise ex
+        end
       end
 
       store_session

--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -134,7 +134,7 @@ module Spaceship
 
         phone_number = env_2fa_sms_default_phone_number
         phone_id = phone_id_from_number(response.body["trustedPhoneNumbers"], phone_number)
-        push_mode = push_mode_from_masked_number(response.body["trustedPhoneNumbers"], phone_number)
+        push_mode = push_mode_from_phone_id(response.body["trustedPhoneNumbers"], phone_id)
         # don't request sms if no trusted devices and env default is the only trusted number,
         # code was automatically sent
         should_request_code = !sms_automatically_sent(response)
@@ -227,6 +227,50 @@ module Spaceship
       ask(text)
     end
 
+    def retrieve_2fa_code_from_url(endpoint_url)
+      # If the 2FA code is delivered with a phone call, chances are that we need to wait for a while for a
+      # transcription to be available. In addition, ideally we'd like to enter the code as soon as we have it to
+      # minimize the chance of it expiring.
+      # As a compromise, let's check for 5 minutes at intervals of 10 seconds
+      max_retries = 30
+      retries = 0
+      wait_between_retries = 10
+
+      while retries < max_retries
+        # Query the URL to check if a 2FA code is available
+        uri = URI(endpoint_url)
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = uri.scheme == 'https'
+
+        # We assume it's a GET request with optional basic authentication that returns a JSON
+        req = Net::HTTP::Get.new(uri)
+        req.basic_auth(uri.user, uri.password) unless uri.user.nil? || uri.password.nil?
+        req.add_field('Content-Type', 'application/json')
+        res = http.request(req)
+
+        # The response must be a 200 OK, contain valid JSON, and include an "auth_code" field that is either
+        # null (no code) or a valid 2FA code.
+        # TODO check the auth code more appropriately (regex?)
+        if res.code.to_i == 200
+          begin
+            data = JSON.parse(res.body)
+            return data["auth_code"] unless data["auth_code"].nil?
+          rescue JSON::ParserError
+            puts("Server response is not a valid JSON.")
+          end
+        end
+
+        puts("Server did not reply with a valid 2FA code, retrying in #{wait_between_retries} seconds...")
+        retries += 1
+        sleep(wait_between_retries)
+      end
+
+      # We did not succeed in authenticating, let's return a mock code to try another round
+      # We use a randomly-generated code to avoid letting Apple discover a pattern in our errors
+      # Note, however, that this should happen quite rarely
+      Array.new(6).map { rand(10) }.join
+    end
+
     # extracted into its own method for testing
     def choose_phone_number(opts)
       choose(*opts)
@@ -277,7 +321,18 @@ If it is, please open an issue at https://github.com/fastlane/fastlane/issues/ne
       end
     end
 
+    def push_mode_from_phone_id(phone_numbers, phone_id)
+      phone_numbers.each do |phone|
+        return phone['pushMode'] if phone['id'] == phone_id
+      end
+
+      # If no pushMode was supplied, assume sms
+      return "sms"
+    end
+
     def push_mode_from_masked_number(phone_numbers, masked_number)
+      # TODO: the usage of this method seems broken: the allegedly masked phone number is actually a non-masked number
+      # Therefore, this check is bound to fail. Maybe we should open a PR on upstream to use the ID instead?
       phone_numbers.each do |phone|
         return phone['pushMode'] if phone['numberWithDialCode'] == masked_number
       end
@@ -294,7 +349,7 @@ If it is, please open an issue at https://github.com/fastlane/fastlane/issues/ne
       end
       chosen = choose_phone_number(available)
       phone_id = phone_id_from_masked_number(phone_numbers, chosen)
-      push_mode = push_mode_from_masked_number(phone_numbers, chosen)
+      push_mode = push_mode_from_phone_id(phone_numbers, phone_id)
 
       request_two_factor_code_from_phone(phone_id, chosen, code_length, push_mode)
     end
@@ -317,7 +372,15 @@ If it is, please open an issue at https://github.com/fastlane/fastlane/issues/ne
         puts("Successfully requested text message to #{phone_number}")
       end
 
-      code = ask_for_2fa_code("Please enter the #{code_length} digit code you received at #{phone_number}:")
+      env_2fa_auto_login_url = ENV["SPACESHIP_2FA_AUTO_LOGIN_URL"]
+
+      if env_2fa_auto_login_url
+        puts("Environment variable `SPACESHIP_2FA_AUTO_LOGIN_URL` is set, automatically loading 2FA from specified URL")
+        puts("")
+        code = retrieve_2fa_code_from_url(env_2fa_auto_login_url)
+      else
+        code = ask_for_2fa_code("Please enter the #{code_length} digit code you received at #{phone_number}:")
+      end
 
       return { "securityCode" => { "code" => code.to_s }, "phoneNumber" => { "id" => phone_id }, "mode" => push_mode }.to_json
     end

--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -1,3 +1,5 @@
+require 'openssl'
+
 require_relative 'globals'
 require_relative 'tunes/tunes_client'
 
@@ -241,6 +243,7 @@ module Spaceship
         uri = URI(endpoint_url)
         http = Net::HTTP.new(uri.host, uri.port)
         http.use_ssl = uri.scheme == 'https'
+        http.verify_mode = OpenSSL::SSL::VERIFY_NONE if ENV["SPACESHIP_2FA_SKIP_SSL_VERIFICATION"]
 
         # We assume it's a GET request with optional basic authentication that returns a JSON
         req = Net::HTTP::Get.new(uri)

--- a/spaceship/spec/fixtures/appleauth_2fa_voice_no_trusted_devices.json
+++ b/spaceship/spec/fixtures/appleauth_2fa_voice_no_trusted_devices.json
@@ -1,0 +1,45 @@
+{
+    "trustedPhoneNumbers": [
+        {
+            "numberWithDialCode": "+49 •••• •••••85",
+            "pushMode": "voice",
+            "obfuscatedNumber": "•••• •••••85",
+            "id": 1
+        }
+    ],
+    "phoneNumber": {
+        "numberWithDialCode": "+49 •••• •••••85",
+        "pushMode": "voice",
+        "obfuscatedNumber": "•••• •••••85",
+        "id": 1
+    },
+    "securityCode": {
+        "length": 6,
+        "tooManyCodesSent": false,
+        "tooManyCodesValidated": false,
+        "securityCodeLocked": false,
+        "securityCodeCooldown": false
+    },
+    "mode": "sms",
+    "type": "verification",
+    "authenticationType": "hsa2",
+    "recoveryUrl": "https://iforgot.apple.com/phone/add?prs_account_nm=email@example.org&autoSubmitAccount=true&appId=142",
+    "cantUsePhoneNumberUrl": "https://iforgot.apple.com/iforgot/phone/add?context=cantuse&prs_account_nm=email@example.org&autoSubmitAccount=true&appId=142",
+    "recoveryWebUrl": "https://iforgot.apple.com/password/verify/appleid?prs_account_nm=email@example.org&autoSubmitAccount=true&appId=142",
+    "repairPhoneNumberUrl": "https://gsa.apple.com/appleid/account/manage/repair/verify/phone",
+    "repairPhoneNumberWebUrl": "https://appleid.apple.com/widget/account/repair?#!repair",
+    "noTrustedDevices": true,
+    "aboutTwoFactorAuthenticationUrl": "https://support.apple.com/kb/HT204921",
+    "autoVerified": false,
+    "showAutoVerificationUI": false,
+    "trustedPhoneNumber": {
+        "numberWithDialCode": "+49 •••• •••••85",
+        "pushMode": "voice",
+        "obfuscatedNumber": "•••• •••••85",
+        "id": 1
+    },
+    "hsa2Account": true,
+    "restrictedAccount": false,
+    "supportsRecovery": true,
+    "managedAccount": false
+}

--- a/spaceship/spec/tunes/tunes_stubbing.rb
+++ b/spaceship/spec/tunes/tunes_stubbing.rb
@@ -55,6 +55,11 @@ class TunesStubbing
           to_return(status: 200, body: "", headers: {})
       end
 
+      # 2FA: Submit security code from trusted phone with voice for verification
+      stub_request(:post, "https://idmsa.apple.com/appleauth/auth/verify/phone/securitycode").
+        with(body: "{\"securityCode\":{\"code\":\"123\"},\"phoneNumber\":{\"id\":1},\"mode\":\"voice\"}").
+        to_return(status: 200, body: "", headers: {})
+
       # 2FA: Submit security code from trusted device for verification
       stub_request(:post, "https://idmsa.apple.com/appleauth/auth/verify/trusteddevice/securitycode").
         with(body: "{\"securityCode\":{\"code\":\"123\"}}").

--- a/spaceship/spec/two_step_or_factor_client_spec.rb
+++ b/spaceship/spec/two_step_or_factor_client_spec.rb
@@ -67,6 +67,7 @@ describe Spaceship::Client do
   describe 'handle_two_factor' do
     let(:trusted_devices_response) { JSON.parse(File.read(File.join('spaceship', 'spec', 'fixtures', 'client_appleauth_auth_2fa_response.json'), encoding: 'utf-8')) }
     let(:no_trusted_devices_response) { JSON.parse(File.read(File.join('spaceship', 'spec', 'fixtures', 'appleauth_2fa_no_trusted_devices.json'), encoding: 'utf-8')) }
+    let(:no_trusted_devices_voice_response) { JSON.parse(File.read(File.join('spaceship', 'spec', 'fixtures', 'appleauth_2fa_voice_no_trusted_devices.json'), encoding: 'utf-8')) }
     let(:no_trusted_devices_two_numbers_response) { JSON.parse(File.read(File.join('spaceship', 'spec', 'fixtures', 'appleauth_2fa_no_trusted_devices_two_numbers.json'), encoding: 'utf-8')) }
 
     context 'when SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER is not set' do
@@ -112,6 +113,18 @@ describe Spaceship::Client do
             expect(WebMock).to have_not_requested(:put, 'https://idmsa.apple.com/appleauth/auth/verify/phone')
             expect(WebMock).to have_not_requested(:post, 'https://idmsa.apple.com/appleauth/auth/verify/trusteddevice/securitycode')
             expect(WebMock).to have_requested(:post, 'https://idmsa.apple.com/appleauth/auth/verify/phone/securitycode').with(body: { securityCode: { code: "123" }, phoneNumber: { id: 1 }, mode: "sms" })
+          end
+
+          it "does not request sms code, and sends the correct request with voice" do
+            response = OpenStruct.new
+            response.body = no_trusted_devices_voice_response
+
+            bool = subject.handle_two_factor(response)
+            expect(bool).to eq(true)
+
+            expect(WebMock).to have_not_requested(:put, 'https://idmsa.apple.com/appleauth/auth/verify/phone')
+            expect(WebMock).to have_not_requested(:post, 'https://idmsa.apple.com/appleauth/auth/verify/trusteddevice/securitycode')
+            expect(WebMock).to have_requested(:post, 'https://idmsa.apple.com/appleauth/auth/verify/phone/securitycode').with(body: { securityCode: { code: "123" }, phoneNumber: { id: 1 }, mode: "voice" })
           end
         end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR introduces an automatic login flow for 2FA-protected Apple accounts.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

- [x] Fix support for 2FA codes supplied via phone calls
- [x] Automatically retrieve 2FA codes from a supplied URL
- [x] Drop cookie auto-deletion on 409 errors
- [x] Introduce cookie expiration mechanism
- [x] Introduce mutex inside `send_shared_login_request()` to avoid concurrent login attempts

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
Tested live with a bunker.