### PR TITLE
[spaceship] Use less aggressive auth mutex

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -424,9 +424,23 @@ module Spaceship
       end
     end
 
-    # Wrapper for send_shared_login_request_helper() that handles concurrent login attempts via a global authentication
-    # mutex. The mutex relies on filesystem locking to work across several processes.
+    # This method is used for both the Apple Dev Portal and App Store Connect
+    # This will also handle 2 step verification and 2 factor authentication
+    #
+    # It is called in `send_login_request` of sub classes (which the method `login`, above, transferred over to via `do_login`)
+    #
+    # BSP: the core logic has been moved to load_cached_session() and login_request_helper(). This method acts as a
+    # wrapper to handle concurrent login attempts via a global authentication mutex. The mutex relies on filesystem
+    # locking to work across several processes.
     def send_shared_login_request(user, password)
+      # Check if we have a cached/valid session
+      return if load_cached_session
+
+      #
+      # After this point, we sure have no valid session any more and have to create a new one
+      #
+
+      # To prevent multiple authentication attempts, this section is protected by a mutex
       authenticated = false
 
       File.open(persistent_auth_mutex_path, "w") do |f|
@@ -435,19 +449,26 @@ module Spaceship
         # When used with File::LOCK_EX, flock() will wait until the lock is released
         f.flock(File::LOCK_EX)
 
-        puts("Obtained lock on authentication mutex, proceeding with login procedure.")
-        authenticated = send_shared_login_request_helper(user, password)
+        # If we get past the lock, it might be either because we're the first process to attempt the renew, or because
+        # we were another request waiting in queue for the renew to happen
+        #
+        # Since we can't know which is which, let's first see if the session has been renewed by the previous holder
+        # of the mutex
+        puts("Obtained lock on authentication mutex, checking if session has been renewed in the meanwhile.")
+
+        authenticated = load_cached_session
+
+        unless authenticated
+          puts("No valid cached session found, proceeding with mutex-protected login.")
+          authenticated = login_request_helper(user, password)
+        end
       end
 
       puts("Authentication lock released.")
       authenticated
     end
 
-    # This method is used for both the Apple Dev Portal and App Store Connect
-    # This will also handle 2 step verification and 2 factor authentication
-    #
-    # It is called in `send_login_request` of sub classes (which the method `login`, above, transferred over to via `do_login`)
-    def send_shared_login_request_helper(user, password)
+    def load_cached_session
       # Check if we have a cached/valid session
       #
       # Background:
@@ -494,10 +515,12 @@ module Spaceship
           # see above
         end
       end
-      #
-      # After this point, we sure have no valid session any more and have to create a new one
-      #
 
+      # No valid session found
+      false
+    end
+
+    def login_request_helper(user, password)
       data = {
         accountName: user,
         password: password,


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
This PR attempts to reduce the likelihood of multiple processes being stuck in the authentication mutex. This should improve the performance and the parallelism of API requests under certain conditions.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
Instead of acquiring the mutex before attempting to load the cookie from the drive, Fastlane now checks the validity of the cookie, and only acquires the mutex in case the cookie is not valid. 
This means that an API request coming from a process will not have to wait in queue if the cookie on disk is still valid, but it's being refreshed by a different process (for example, a preemptive background refresher). However, this won't help in case the different processes are using the same cookie (which therefore expires at the same time).

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
To be tested live with a bunker.