### PR TITLE
fix: add missing client var in do wait for processing

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/app_preview.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_preview.rb
@@ -143,13 +143,14 @@ module Spaceship
         # Poll for video processing completion to set still frame time
         wait_for_processing = true unless frame_time_code.nil?
         if wait_for_processing
-          do_wait_for_processing(app_preview_id: preview.id, frame_time_code: frame_time_code)
+          do_wait_for_processing(client: client, app_preview_id: preview.id, frame_time_code: frame_time_code)
         end
 
         preview
       end
 
-      def self.do_wait_for_processing(app_preview_id: nil, frame_time_code: nil)
+      def self.do_wait_for_processing(client: nil, app_preview_id: nil, frame_time_code: nil)
+        client ||= Spaceship::ConnectAPI
         loop do
           preview = Spaceship::ConnectAPI::AppPreview.get(client: client, app_preview_id: app_preview_id)
           unless preview.video_url.nil?


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
An error was encountered during a metadata upload. The error states:
```
undefined local variable or method `client' for Spaceship::ConnectAPI::AppPreview:Class
["/usr/local/bundle/bundler/gems/fastlane-440fc23898be/spaceship/lib/spaceship/connect_api/models/app_preview.rb:154 ...
```
The error was introduced in the recent Fastlane rebasing.

### Description
Add the `client` parameter to the `do_wait_for_processing` method and initialise it in case it is `nil`. Additionally, pass the client from `create` when calling `do_wait_for_processing`.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
